### PR TITLE
apply logger instance to request

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,7 @@ constructor(options) {
 - `protocol`: Defaults to 'http'.
 - `env`: Can be used to switch contexts. Defaults to 'development'.
 - `gaTagId`: Google analytics tag.
+- `loglevel`: Defaults to `info`. Logger is bound to the request object, accessible on every request.
 - `redis.port`: Defaults to '6379'.
 - `redis.host`: Defaults '127.0.0.1'.
 - `session.ttl`: The session timeout in milliseconds. Defaults to `1800` (ms).
@@ -69,6 +70,7 @@ boostrap.configure('root', path.resolve(__dirname, '..'));
 - `PROTOCOL`
 - `ENV`
 - `GA_TAG`
+- `LOG_LEVEL`
 - `REDIS_HOST`
 - `REDIS_PORT`
 - `SESSION_TTL`

--- a/index.js
+++ b/index.js
@@ -117,10 +117,8 @@ function bootstrap(options) {
     }
   });
 
-  if (config.env !== 'test' && config.env !== 'ci') {
-    config.logger = logger(config);
-    app.use(churchill(config.logger));
-  }
+  config.logger = logger(config);
+  app.use(churchill(config.logger));
 
   if (config.middleware) {
     config.middleware.forEach(middleware => app.use(middleware));

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const winston = require('winston');
-const loggingTransports = [];
-const exceptionTransports = [];
 
 module.exports = (config) => {
+  const loggingTransports = [];
+  const exceptionTransports = [];
   const notProd = config.env !== 'production';
   const levels = {
     info: 0,

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "scripts": {
     "test": "npm run unit && npm run lint",
-    "unit": "NODE_ENV=test istanbul cover _mocha",
-    "unit:nocov": "NODE_ENV=test mocha",
+    "unit": "LOG_LEVEL=error istanbul cover _mocha",
+    "unit:nocov": "LOG_LEVEL=error mocha",
     "lint": "eslint .",
     "snyk": "snyk test",
     "snyk:dev": "snyk test --dev",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "body-parser": "^1.15.1",
-    "churchill": "0.0.5",
+    "churchill": "1.1.1",
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.1",
     "deprecate": "^1.0.0",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const request = require('supertest-as-promised');
+
 const bootstrap = require('../../');
+
 const path = require('path');
 const appConfig = {
   foo: 'bar',


### PR DESCRIPTION
So we can use the logger instance in any method invoked with a request object 