### PR TITLE
Remove non-standard log levels

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,24 +3,14 @@
 const winston = require('winston');
 
 module.exports = (config) => {
+
   const loggingTransports = [];
   const exceptionTransports = [];
   const notProd = config.env !== 'production';
-  const levels = {
-    info: 0,
-    email: 1,
-    warn: 2,
-    error: 3
-  };
-  const colors = {
-    info: 'green',
-    email: 'magenta',
-    warn: 'yellow',
-    error: 'red'
-  };
 
   loggingTransports.push(
     new winston.transports.Console({
+      silent: config.loglevel === 'silent',
       level: config.loglevel,
       json: !notProd,
       timestamp: true,
@@ -43,7 +33,6 @@ module.exports = (config) => {
   );
 
   const transports = {
-    levels: levels,
     transports: loggingTransports,
     exceptionHandlers: exceptionTransports,
     exitOnError: true
@@ -54,8 +43,6 @@ module.exports = (config) => {
   }
 
   const logger = new winston.Logger(transports);
-
-  winston.addColors(colors);
 
   return logger;
 };

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "i18n-future": "^1.0.0",
     "lodash": "^4.17.4",
     "redis": "^2.6.0-2",
-    "winston": "^1.1.2"
+    "winston": "^2.3.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
I'm not aware of any need for the custom levels, but they make trying to do logging in a predictable way difficult because the expected log levels don't exist and so logging `debug` or `verbose` level messages fails silently.

Remove the custom log levels and use the default levels instead.

If there's a reason we do need those custom levels then we can add them back in but with the standard levels included.