### PR TITLE
Pass logger into error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ const applyErrorMiddlewares = (app, config) => {
   }));
 
   app.use(hofMiddleware.errors({
+    logger: config.logger,
     debug: config.env === 'development'
   }));
 };


### PR DESCRIPTION
This means that the error handler which actually write errors to the log instead of erroring out without leaving a trace.