### PR TITLE
Change static server flag to be explicit config

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -23,7 +23,8 @@ const defaults = {
     ttl: process.env.SESSION_TTL || 1800,
     secret: process.env.SESSION_SECRET || 'changethis',
     name: process.env.SESSION_NAME || 'hod.sid'
-  }
+  },
+  serveStatic: process.env.SERVE_STATIC_FILES !== 'false'
 };
 
 module.exports = defaults;

--- a/lib/serve-static.js
+++ b/lib/serve-static.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 module.exports = (app, config) => {
 
-  if (config.env !== 'production') {
+  if (config.serveStatic !== false) {
     app.use('/public', express.static(path.resolve(config.root, 'public')));
   }
 


### PR DESCRIPTION
By inferring from the `NODE_ENV` as to whether to serve static assets in-app we are being over-opinionated about the infrastructure being used to run a hof service. In particular we are saying it is entirely necessary to have some kind of nginx proxy in front of *all* hof apps, which seems unnecessarily strict.

Instead allow the static middleware to be mounted in all cases unless explicitly disabled. In cases where a proxy is in place then the route will be effectively a no-op, since `/public` routes will be caught by nginx and should not hit the node app. However, the static mounting can still be disabled if desired by setting the appropriate config flag.