### PR TITLE
Added ability to pass configuration from bootstrap configuration to markdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ const getConfig = function getConfig() {
     config.theme = require(`hof-theme-${config.theme}`);
   }
 
+  config.markdown = config.markdown || {};
+
   return config;
 };
 
@@ -134,7 +136,7 @@ function bootstrap(options) {
     path: path.resolve(config.root, config.translations) + '/__lng__/__ns__.json'
   }));
   app.use(mixins());
-  app.use(markdown());
+  app.use(markdown(config.markdown));
 
   if (config.getCookies === true) {
     app.get('/cookies', (req, res) => {


### PR DESCRIPTION
Added code to allow the markdown configuration to be brought in through the bootstrap configuration file. This allows for the ability to set a default fallback language for markdown, the issue was brought to attention in acceptance tests we ran on our current HOF project where locale wasn't set in the browser and the application was producing an error.