### PR TITLE
Update form wizard version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express-partial-templates": "^0.2.0",
     "express-session": "^1.13.0",
     "helmet": "^2.3.0",
-    "hof-form-wizard": "^4.3.0",
+    "hof-form-wizard": "^4.4.0",
     "hof-middleware": "^2.0.0",
     "hof-middleware-markdown": "^1.0.0",
     "hof-template-mixins": "^4.2.2",


### PR DESCRIPTION
We need to be able to depend on the custom confirm url functionality added to `hof-form-wizard` in 4.4.0