### PR TITLE
Explicitly enable CSP config for unit test that depends on it

### DIFF
--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -511,6 +511,7 @@ describe('bootstrap()', () => {
 
     it('CSP extends with google directives if gaTagId set', () => {
       const bs = bootstrap({
+        csp: {},
         fields: 'fields',
         gaTagId: '1234-ABC',
         routes: [{


### PR DESCRIPTION
I had an environment variable of `DISABLE_CSP` set in my profile to make functional tests easier to run locally. This meant that this unit test failed because it depends on csp not being disabled.

Set the config explicitly so it does not depend on the environment variable.