### PR TITLE
Pass `confirmStep` from app options into form wizard

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -19,12 +19,18 @@ function getWizardConfig(config) {
   const wizardConfig = {
     name: config.route.name || (config.route.baseUrl || '').replace('/', '')
   };
-  if (config.route.params) {
-    wizardConfig.params = config.route.params;
-  }
+
   if (config.appConfig) {
     wizardConfig.appConfig = config.appConfig;
   }
+
+  // whitelist properties from the route's config that should be passed into the form wizard
+  const props = [
+    'confirmStep',
+    'params'
+  ];
+  Object.assign(wizardConfig, _.pick(config.route, props));
+
   return wizardConfig;
 }
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -37,6 +37,11 @@ describe('bootstrap()', () => {
     bootstrap.configure('root', root);
   });
 
+  beforeEach(() => {
+    behaviourOptions = null;
+    behaviourCalled = false;
+  });
+
   it('must be given a list of routes', () =>
     (() => bootstrap()).should.Throw('Must be called with a list of routes')
   );
@@ -438,7 +443,7 @@ describe('bootstrap()', () => {
     });
 
     it('can instantiate a custom behaviour for the route', () => {
-      const bs = bootstrap({
+      bootstrap({
         fields: 'fields',
         routes: [{
           views: `${root}/apps/app_1/views`,
@@ -449,16 +454,11 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
-        .get('/one')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(() =>
-          behaviourCalled.should.equal(true)
-        );
+      behaviourCalled.should.equal(true);
     });
 
-    it('can pass the app config to a custom behaviour', () => {
-      const bs = bootstrap({
+    it('can pass the app config to controllers', () => {
+      bootstrap({
         fields: 'fields',
         appConfig: appConfig,
         routes: [{
@@ -470,12 +470,24 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
-        .get('/one')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(() =>
-          behaviourOptions.appConfig.should.deep.equal(appConfig)
-        );
+      behaviourOptions.appConfig.should.deep.equal(appConfig);
+    });
+
+    it('can pass the confirm step to controllers', () => {
+      bootstrap({
+        fields: 'fields',
+        appConfig: appConfig,
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          confirmStep: '/summary',
+          steps: {
+            '/one': {
+              behaviours: behaviour
+            }
+          }
+        }]
+      });
+      behaviourOptions.confirmStep.should.equal('/summary');
     });
 
     it('can extend CSP directives with CSP config', () => {


### PR DESCRIPTION
This allows an app to configure its own confirm step, and not be bound strictly to `/confirm`

I assumed in #154 that options passed into the bootstrap function on an app would automatically passed to the form wizard. This was mistaken. The options need to be passed explicitly.