### PR TITLE
Decouple custom csp directives and disabling csp

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const getContentSecurityPolicy = config => {
     directives.imgSrc = directives.imgSrc.concat(gaDirectives.imgSrc);
   }
 
-  if (_.isPlainObject(csp)) {
+  if (_.isPlainObject(csp) && !csp.disabled) {
     _.each(csp, (value, name) => {
       if (directives[name] && directives[name].length) {
         // concat unique directives with existing directives
@@ -102,7 +102,7 @@ function bootstrap(options) {
 
   app.use(helmet());
 
-  if (config.csp) {
+  if (config.csp !== false && !config.csp.disabled) {
     app.use(helmet.contentSecurityPolicy({
       directives: getContentSecurityPolicy(config)
     }));

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -5,7 +5,9 @@ const defaults = {
   root: process.cwd(),
   translations: 'translations',
   start: true,
-  csp: process.env.DISABLE_CSP !== 'true',
+  csp: {
+    disabled: process.env.DISABLE_CSP === 'true'
+  },
   getCookies: true,
   getTerms: true,
   viewEngine: 'html',

--- a/test/common.js
+++ b/test/common.js
@@ -2,6 +2,7 @@
 
 global.chai = require('chai').use(require('sinon-chai'));
 global.should = chai.should();
+global.expect = chai.expect;
 global.sinon = require('sinon');
 require('sinomocha')();
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -23,6 +23,9 @@ const behaviour = SuperClass => class extends SuperClass {
 
 function getHeaders(res, type) {
   let headers = {};
+  if (!res.headers[type]) {
+    return null;
+  }
   let parts = res.headers[type].split('; ');
   parts.forEach((part) => {
     part = part.split(' ');
@@ -518,6 +521,48 @@ describe('bootstrap()', () => {
           csp['script-src'].should.include(directives.scriptSrc);
           csp['test-src'].should.include(directives.testSrc);
           csp['style-src'].should.deep.equal(directives.styleSrc);
+        });
+    });
+
+    it('can disable CSP directives with csp.disabled', () => {
+      const bs = bootstrap({
+        fields: 'fields',
+        csp: {
+          disabled: true
+        },
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          steps: {
+            '/one': {}
+          }
+        }]
+      });
+      return request(bs.server)
+        .get('/one')
+        .set('Cookie', ['myCookie=1234'])
+        .expect((res) => {
+          const csp = getHeaders(res, 'content-security-policy');
+          expect(csp).to.be.null;
+        });
+    });
+
+    it('can disable CSP directives with csp === false', () => {
+      const bs = bootstrap({
+        fields: 'fields',
+        csp: false,
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          steps: {
+            '/one': {}
+          }
+        }]
+      });
+      return request(bs.server)
+        .get('/one')
+        .set('Cookie', ['myCookie=1234'])
+        .expect((res) => {
+          const csp = getHeaders(res, 'content-security-policy');
+          expect(csp).to.be.null;
         });
     });
 


### PR DESCRIPTION
If an app needs to set custom directives then it cannot currently also leave the disabling of csp by setting `DISABLE_CSP` env var intact, so implementations need to implement this as well as it being implemented in `hof`, which is not ideal.

By splitting the disabling of csp from a top level `csp: false` property, to a sub-property of `disabled` then custom directives can be set, but will also be globally disabled independently, and the `DISABLE_CSP` environment variable is still respected.

Leaves the option to disable by setting `csp: false` for backwards compatability.