### PR TITLE
Prevent `disabled` csp directive being added

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,8 +80,11 @@ const getContentSecurityPolicy = config => {
     directives.imgSrc = directives.imgSrc.concat(gaDirectives.imgSrc);
   }
 
-  if (_.isPlainObject(csp) && !csp.disabled) {
+  if (csp && !csp.disabled) {
     _.each(csp, (value, name) => {
+      if (name === 'disabled') {
+        return;
+      }
       if (directives[name] && directives[name].length) {
         // concat unique directives with existing directives
         directives[name] = _.uniq(directives[name].concat(value));

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -566,6 +566,25 @@ describe('bootstrap()', () => {
         });
     });
 
+    it('does not try to add a `disabled` directive', () => {
+      const bs = bootstrap({
+        fields: 'fields',
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          steps: {
+            '/one': {}
+          }
+        }]
+      });
+      return request(bs.server)
+        .get('/one')
+        .set('Cookie', ['myCookie=1234'])
+        .expect((res) => {
+          const csp = getHeaders(res, 'content-security-policy');
+          csp.should.not.have.property('disabled');
+        });
+    });
+
     it('CSP extends with google directives if gaTagId set', () => {
       const bs = bootstrap({
         csp: {},


### PR DESCRIPTION
When `csp.disabled === false` a directive of `disabled` was being added to the directives in the csp header. This caused a warning to be thrown in the browser. Prevent this from occurring.