### PR TITLE
Add a readiness check

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const hofMiddleware = require('hof-middleware');
 const markdown = require('hof-middleware-markdown');
 const translate = require('i18n-future').middleware;
 const router = require('./lib/router');
+const health = require('./lib/health');
 const serveStatic = require('./lib/serve-static');
 const sessionStore = require('./lib/sessions');
 const settings = require('./lib/settings');
@@ -111,9 +112,6 @@ function bootstrap(options) {
     }));
   }
 
-  // shallow health check
-  app.get('/healthz/ping', require('express-healthcheck')());
-
   if (!config || !config.routes || !config.routes.length) {
     throw new Error('Must be called with a list of routes');
   }
@@ -133,7 +131,8 @@ function bootstrap(options) {
 
   serveStatic(app, config);
   settings(app, config);
-  sessionStore(app, config);
+  let sessions = sessionStore(app, config);
+  app.use('/healthz', health(sessions));
 
   app.use(translate({
     resources: config.theme.translations,

--- a/lib/health.js
+++ b/lib/health.js
@@ -1,0 +1,26 @@
+/*
+ * This file provides readiness and liveness checks for use with Kubernetes.
+ * For information on how to set them up, look at the Kubernetes documentation:
+ *
+ * https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+ *
+ */
+'use strict';
+
+const router = require('express').Router();
+const healthCheck = require('express-healthcheck');
+
+module.exports = (redis) => {
+  router.get('/ping', healthCheck());
+
+  router.get('/readiness', healthCheck({
+    test: () => {
+      if (!redis.connected && !redis.ready) {
+        return new Error('Session store unhealthy');
+      }
+      return 0;
+    }
+  }));
+
+  return router;
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "13.3.3",
+  "version": "13.4.0",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -445,6 +445,20 @@ describe('bootstrap()', () => {
         .expect(200);
     });
 
+    it('returns a 200 for successful deeper health check', () => {
+      const bs = bootstrap({
+        fields: 'fields',
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          steps: {}
+        }]
+      });
+      return request(bs.server)
+        .get('/healthz/readiness')
+        .set('Cookie', ['myCookie=1234'])
+        .expect(200);
+    });
+
     it('can instantiate a custom behaviour for the route', () => {
       bootstrap({
         fields: 'fields',


### PR DESCRIPTION
hof already has a "ping" check, that just ensures the app is alive.
This means that we can set up "liveness" checks with Kubernetes or
another platform.

This commit adds a "readiness" check too, which is a bit deeper.
It checks that the session store is accessible as well.