### PR TITLE
SD-75: Address ZAP report issues to Improve Cookie Security

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ const getContentSecurityPolicy = (config, res) => {
  *     @see {@link https://github.com/UKHomeOfficeForms/hof-middleware-markdown}
  * @param options.getTerms {boolean} Optional boolean - whether to mount the /terms endpoint
  * @param options.getCookies {boolean} Optional boolean - whether to mount the /cookies endpoint
+ * @param options.noCache {boolean} Optional boolean - whether to disable caching
  *
  * @returns {object} A new HOF application using the configuration supplied in options
  */
@@ -142,6 +143,14 @@ function bootstrap(options) {
   }
 
   app.use(helmet.noSniff());
+
+  if (config.noCache && config.noCache !== 'false') {
+    app.use((req, res, next) => {
+      res.setHeader('cache-control', ['no-store', 'no-cache', 'must-revalidate', 'proxy-revalidate']);
+      res.setHeader('pragma', 'no-cache');
+      next();
+    });
+  }
 
   if (!config || !config.routes || !config.routes.length) {
     throw new Error('Must be called with a list of routes');

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -13,6 +13,7 @@ const defaults = {
   getTerms: true,
   viewEngine: 'html',
   protocol: process.env.PROTOCOL || 'http',
+  noCache: process.env.NO_CACHE || false,
   host: process.env.HOST || '0.0.0.0',
   port: process.env.PORT || '8080',
   env: process.env.NODE_ENV || 'development',

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -65,10 +65,10 @@ module.exports = (app, config) => {
   const sessionOpts = Object.assign({
     store,
     name: config.session.name,
-    cookie: {secure: config.protocol === 'https'},
+    cookie: {secure: config.protocol === 'https', sameSite: 'strict', httpOnly: true},
     secret: config.session.secret,
     saveUninitialized: true,
-    resave: true,
+    resave: true
   }, config.session);
 
   app.use(session(sessionOpts));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "18.0.0",
+  "version": "18.1.0",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
Addresses a few issues raised by an automated security scan:
* add sameSite: 'strict' attribute to session cookie
* disable caching
* set session cookie to httpOnly (prevents browser js reading it)