### PR TITLE
SD-95 - Address package vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 npm-debug.log
 .idea
 package-lock.json
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "18.1.0",
+  "version": "18.2.0",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "test": "npm run unit && npm run lint",
-    "unit": "LOG_LEVEL=error istanbul cover _mocha",
+    "unit": "LOG_LEVEL=error nyc _mocha \"test/integration/**/*.spec.js\"",
     "unit:nocov": "LOG_LEVEL=error mocha",
     "lint": "eslint .",
     "ci": "travis-conditions"
@@ -48,17 +48,22 @@
     "chai": "^3.5.0",
     "debug": "^2.2.0",
     "eslint-config-homeoffice": "^2.1.0",
-    "istanbul": "^0.4.3",
-    "mocha": "^2.4.5",
+    "nyc": "^15.1.0",
+    "mocha": "^8.2.1",
     "pre-commit": "^1.1.3",
     "proxyquire": "^1.7.11",
     "request": "^2.79.0",
-    "sinomocha": "^0.2.4",
-    "sinon": "^1.17.5",
-    "sinon-chai": "^2.8.0",
+    "sinon": "^9.2.1",
+    "sinon-chai": "^3.5.0",
     "supertest": "^3.0.0",
-    "supertest-as-promised": "^3.2.0",
     "travis-conditions": "0.0.0"
+  },
+  "mocha": {
+    "reporter": "spec",
+    "require": "test/common.js",
+    "recursive": "true",
+    "timeout": "6000",
+    "exit": "true"
   },
   "optionalDependencies": {
     "hof-theme-govuk": "^5.1.1"

--- a/test/common.js
+++ b/test/common.js
@@ -6,7 +6,6 @@ global.chai = require('chai').use(require('sinon-chai'));
 global.should = chai.should();
 global.expect = chai.expect;
 global.sinon = require('sinon');
-require('sinomocha')();
 
 process.setMaxListeners(0);
 process.stdout.setMaxListeners(0);

--- a/test/integration/behaviours.spec.js
+++ b/test/integration/behaviours.spec.js
@@ -7,8 +7,10 @@ describe('Behaviours', () => {
 
   let wizard;
   let bootstrap;
+  let bs;
 
   beforeEach(() => {
+    bs = null;
     wizard = sinon.stub().returns(() => {});
     bootstrap = proxyquire('../../', {
       './lib/router': proxyquire('../../lib/router', {
@@ -18,10 +20,16 @@ describe('Behaviours', () => {
     bootstrap.configure('root', path.resolve(__dirname, '../fixtures'));
   });
 
+  afterEach(() => {
+    if (bs) {
+      bs.stop();
+    }
+  });
+
   describe('route-level behaviours', () => {
 
     it('applies behaviours to all steps in specified route', () => {
-      bootstrap({
+      bs = bootstrap({
         fields: 'fields',
         routes: [
           {
@@ -60,7 +68,7 @@ describe('Behaviours', () => {
   describe('global behaviours', () => {
 
     it('applies behaviours to all steps in all routes', () => {
-      bootstrap({
+      bs = bootstrap({
         fields: 'fields',
         behaviours: ['behaviour-one'],
         routes: [
@@ -99,7 +107,7 @@ describe('Behaviours', () => {
   describe('global and route-level behaviours', () => {
 
     it('applies global behaviours before route-level behaviours', () => {
-      bootstrap({
+      bs = bootstrap({
         fields: 'fields',
         behaviours: ['behaviour-one'],
         routes: [

--- a/test/integration/bootstrap.spec.js
+++ b/test/integration/bootstrap.spec.js
@@ -1,0 +1,205 @@
+'use strict';
+/* eslint-disable no-return-assign */
+
+const testTag = 'Test-GA-Tag';
+process.env.GA_TAG = testTag;
+
+const bootstrap = require('../../');
+
+const path = require('path');
+const appConfig = {
+  foo: 'bar',
+  bar: 'baz'
+};
+const root = path.resolve(__dirname, '../fixtures');
+
+let behaviourOptions = null;
+let behaviourCalled = false;
+const behaviour = SuperClass => class extends SuperClass {
+  constructor(options) {
+    behaviourCalled = true;
+    behaviourOptions = options;
+    super(options);
+  }
+};
+
+describe('bootstrap()', () => {
+  let bs;
+
+  before(() => {
+    bootstrap.configure('root', root);
+  });
+
+  beforeEach(() => {
+    behaviourOptions = null;
+    behaviourCalled = false;
+    bs = null;
+  });
+
+  afterEach(() => {
+    if (bs) {
+      bs.stop();
+    }
+  });
+
+  it('must be given a list of routes', () => {
+      return (() => bs = bootstrap()).should.Throw('Must be called with a list of routes');
+    }
+  );
+
+  it('routes must each have a set of one or more steps, or one or more pages', () =>
+    (() => bs = bootstrap({
+      routes: [{}]
+    })).should.Throw('Each app must have steps and/or pages')
+  );
+
+  it('a base fields option must be specified if no route fields option is defined', () =>
+    (() => bs = bootstrap({
+      fields: 'fields',
+      routes: [{
+        steps: {}
+      }]
+    })).should.not.Throw()
+  );
+
+  it('a route fields option must be specified if no base fields option is defined', () =>
+    (() => bs = bootstrap({
+      routes: [{
+        fields: 'apps/app_1/fields',
+        steps: {}
+      }]
+    })).should.not.Throw()
+  );
+
+  it('one of base fields or route fields must be specified as an option', () =>
+    (() => bs = bootstrap({
+      routes: [{
+        steps: {}
+      }]
+    })).should.Throw('Set base fields or route fields or both')
+  );
+
+  it('fields option must be valid when specified', () =>
+    (() => bootstrap({
+      fields: 'not_a_valid_path',
+      routes: [{
+        steps: {},
+      }]
+    })).should.Throw(`Cannot find fields at ${root}/not_a_valid_path`)
+  );
+
+  it('route fields option must be valid when specified', () =>
+    (() => bs = bootstrap({
+      routes: [{
+        steps: {},
+        fields: 'not_a_valid_path'
+      }]
+    })).should.Throw(`Cannot find route fields at ${root}/not_a_valid_path`)
+  );
+
+  it('uses defaults when no views option is specified', () =>
+    (() => bs = bootstrap({
+      fields: 'fields',
+      routes: [{
+        steps: {}
+      }]
+    })).should.not.Throw()
+  );
+
+  it('views option must be valid when specified', () =>
+    (() => bs = bootstrap({
+      fields: 'fields',
+      views: 'invalid_path',
+      routes: [{
+        steps: {}
+      }]
+    })).should.Throw(`Cannot find views at ${root}/invalid_path`)
+  );
+
+  it('route views option must be valid when specified', () =>
+    (() => bs = bootstrap({
+      fields: 'fields',
+      routes: [{
+        views: 'invalid_path',
+        steps: {}
+      }]
+    })).should.Throw(`Cannot find route views at ${root}/invalid_path`)
+  );
+
+  it('does not throw if no route views option is specified and the default route views directory does not exist', () =>
+    (() => bs = bootstrap({
+      fields: 'fields',
+      routes: [{
+        name: 'app_3',
+        steps: {}
+      }]
+    })).should.not.Throw()
+  );
+
+  describe('with valid routes and steps', () => {
+
+    it('returns the bootstrap interface object', () => {
+        bs = bootstrap({
+          fields: 'fields',
+          routes: [{
+            views: `${root}/apps/app_1/views`,
+            steps: {
+              '/one': {}
+            }
+          }]
+        });
+
+        return bs.should.have.all.keys('server', 'stop', 'start', 'use');
+      }
+    );
+
+    it('can instantiate a custom behaviour for the route', () => {
+      bs = bootstrap({
+        fields: 'fields',
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          steps: {
+            '/one': {
+              behaviours: behaviour
+            }
+          }
+        }]
+      });
+
+      behaviourCalled.should.equal(true);
+    });
+
+    it('can pass the app config to controllers', () => {
+      bs = bootstrap({
+        fields: 'fields',
+        appConfig: appConfig,
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          steps: {
+            '/one': {
+              behaviours: behaviour
+            }
+          }
+        }]
+      });
+      behaviourOptions.appConfig.should.deep.equal(appConfig);
+    });
+
+    it('can pass the confirm step to controllers', () => {
+      bs = bootstrap({
+        fields: 'fields',
+        appConfig: appConfig,
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          confirmStep: '/summary',
+          steps: {
+            '/one': {
+              behaviours: behaviour
+            }
+          }
+        }]
+      });
+      behaviourOptions.confirmStep.should.equal('/summary');
+    });
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---require test/common.js
---recursive
---reporter spec


### PR DESCRIPTION
This pull request updates mocha to fix vulnerabilities. The previous version was very old, so it necessitated other changes.
* update mocha version
* update istanbul to nyc
* update sinon
* update sinon-chai
* replace supertest-as-promised with latest supertest (this now supports promises)
* remove sinomocha as it breaks under latest mocha
* amend tests to run under new mocha version
* use standard naming pattern for test files
* split index.spec.js (bootstrap.spec.js and server.spec.js) into two smaller files