### PR TITLE
[MINOR] Radio button required attribute removed

### DIFF
--- a/frontend/themes/gov-uk/views/partials/forms/option-group.html
+++ b/frontend/themes/gov-uk/views/partials/forms/option-group.html
@@ -11,8 +11,7 @@
                 type="{{type}}"
                 name="{{key}}"
                 id="{{key}}-{{value}}"
-                value="{{value}}"
-                required="true"
+                value="{{value}}"                
                 {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
                 {{#selected}} checked="checked"{{/selected}}
                 {{^error}}{{#optionHint}} aria-describedby="{{key}}-{{value}}-hint"{{/optionHint}}{{^optionHint}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}{{/optionHint}}{{/error}}


### PR DESCRIPTION
What?
Removed the required attribute for radio button options.

Why? 
For RIL-302, radio buttons should not be announced as 'required'. 

Note: 
Template used for RIL modified, there is another template for radio buttons which is not modified 
 
