### PR TITLE
HOFF-166 complex form search select step

### DIFF
--- a/example/apps/example-app/behaviours/country-select.js
+++ b/example/apps/example-app/behaviours/country-select.js
@@ -1,0 +1,10 @@
+module.exports = superclass => class extends superclass {
+    configure(req, res, next) {
+      const homeOfficeCountries = [''].concat(require('homeoffice-countries').allCountries);
+      req.form.options.fields['countrySelect'].options = homeOfficeCountries.map(country => {
+        const labelString = country !== '' ? country : 'Please select a country';
+        return { label: labelString, value: country };
+      });
+      next();
+    }
+  };

--- a/example/apps/example-app/behaviours/country-select.js
+++ b/example/apps/example-app/behaviours/country-select.js
@@ -1,10 +1,10 @@
 module.exports = superclass => class extends superclass {
-    configure(req, res, next) {
-      const homeOfficeCountries = [''].concat(require('homeoffice-countries').allCountries);
-      req.form.options.fields['countrySelect'].options = homeOfficeCountries.map(country => {
-        const labelString = country !== '' ? country : 'Please select a country';
-        return { label: labelString, value: country };
-      });
-      next();
-    }
-  };
+  configure(req, res, next) {
+    const homeOfficeCountries = [''].concat(require('homeoffice-countries').allCountries);
+    req.form.options.fields.countrySelect.options = homeOfficeCountries.map(country => {
+      const labelString = country !== '' ? country : 'Please select a country';
+      return { label: labelString, value: country };
+    });
+    next();
+  }
+};

--- a/example/apps/example-app/fields.js
+++ b/example/apps/example-app/fields.js
@@ -85,7 +85,7 @@ module.exports = {
   },
   countrySelect: {
     mixin: 'select',
-    className: ['typeahead', 'js-hidden'],
+    className: ['typeahead'],
     options: [''].concat(require('homeoffice-countries').allCountries),
     legend: {
       className: 'visuallyhidden'

--- a/example/apps/example-app/fields.js
+++ b/example/apps/example-app/fields.js
@@ -82,5 +82,14 @@ module.exports = {
       attribute: 'rows',
       value: 8
     }]
+  },
+  countrySelect: {
+    mixin: 'select',
+    className: ['typeahead', 'js-hidden'],
+    options: [''].concat(require('homeoffice-countries').allCountries),
+    legend: {
+      className: 'visuallyhidden'
+    },
+    validate: ['required']
   }
 }

--- a/example/apps/example-app/index.js
+++ b/example/apps/example-app/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 'use strict';
 
+const CountrySelect = require('./behaviours/country-select');
 const SummaryPageBehaviour = require('../../../').components.summary;
 const InternationalPhoneNumber = require('./behaviours/international-number');
 
@@ -39,7 +40,7 @@ module.exports = {
     '/radio':{
       fields: ['countryOfHearing'],
       forks: [{
-        target: '/text-input-area',
+        target: '/country-select',
         condition: {
           field: 'landing-page-radio',
           value: 'complex-form'
@@ -54,6 +55,12 @@ module.exports = {
     '/phone-number': {
       fields: ['phone'],
       next: '/confirm'
+    },
+    '/country-select' : {
+      behaviours: CountrySelect,
+      fields: ['countrySelect'],
+      continueOnEdit: true,
+      next:'/text-input-area'
     },
     '/text-input-area': {
       fields: ['complaintDetails'],

--- a/example/apps/example-app/index.js
+++ b/example/apps/example-app/index.js
@@ -68,7 +68,41 @@ module.exports = {
     },
     '/confirm': {
       behaviours: [SummaryPageBehaviour, 'complete'],
+<<<<<<< HEAD
       sections: require('./sections/summary-data-sections'),
+=======
+      sections: {
+        applicantsDetails: [
+          'name',
+          {
+            field: 'dateOfBirth',
+            parse: d => d && moment(d).format(PRETTY_DATE_FORMAT)
+          }
+        ],
+        address: [
+          'building',
+          'street',
+          'townOrCity',
+          'postcode'
+        ],
+        income: [
+          'incomeTypes'
+        ], 
+        appealDetails: [
+          'countryOfHearing'
+        ],
+        contactDetails: [
+          'email',
+          'phone'
+        ], 
+        complaintDetails: [
+          'complaintDetails'
+        ],
+        countrySelect: [
+          'countrySelect'
+        ]
+      },
+>>>>>>> add country search select
       next: '/confirmation'
     },
     '/confirmation': {

--- a/example/apps/example-app/index.js
+++ b/example/apps/example-app/index.js
@@ -68,41 +68,7 @@ module.exports = {
     },
     '/confirm': {
       behaviours: [SummaryPageBehaviour, 'complete'],
-<<<<<<< HEAD
       sections: require('./sections/summary-data-sections'),
-=======
-      sections: {
-        applicantsDetails: [
-          'name',
-          {
-            field: 'dateOfBirth',
-            parse: d => d && moment(d).format(PRETTY_DATE_FORMAT)
-          }
-        ],
-        address: [
-          'building',
-          'street',
-          'townOrCity',
-          'postcode'
-        ],
-        income: [
-          'incomeTypes'
-        ], 
-        appealDetails: [
-          'countryOfHearing'
-        ],
-        contactDetails: [
-          'email',
-          'phone'
-        ], 
-        complaintDetails: [
-          'complaintDetails'
-        ],
-        countrySelect: [
-          'countrySelect'
-        ]
-      },
->>>>>>> add country search select
       next: '/confirmation'
     },
     '/confirmation': {

--- a/example/apps/example-app/index.js
+++ b/example/apps/example-app/index.js
@@ -59,7 +59,6 @@ module.exports = {
     '/country-select' : {
       behaviours: CountrySelect,
       fields: ['countrySelect'],
-      continueOnEdit: true,
       next:'/text-input-area'
     },
     '/text-input-area': {

--- a/example/apps/example-app/sections/summary-data-sections.js
+++ b/example/apps/example-app/sections/summary-data-sections.js
@@ -27,5 +27,8 @@ module.exports = {
   ],
   complaintDetails: [
     'complaintDetails'
+  ],
+  countrySelect: [
+    'countrySelect'
   ]
 };

--- a/example/apps/example-app/translations/src/en/fields.json
+++ b/example/apps/example-app/translations/src/en/fields.json
@@ -81,7 +81,7 @@
     "label": "Complaint details"
   },
   "countrySelect": {
-    "label": "Selet a country",
-    "hint": "Start to type the country name"
+    "label": "Select a country",
+    "hint": "Start to type the country name and options will appear"
   }
 }

--- a/example/apps/example-app/translations/src/en/fields.json
+++ b/example/apps/example-app/translations/src/en/fields.json
@@ -79,5 +79,9 @@
   },
   "complaintDetails": {
     "label": "Complaint details"
+  },
+  "countrySelect": {
+    "label": "Selet a country",
+    "hint": "Start to type the country name"
   }
 }

--- a/example/apps/example-app/translations/src/en/pages.json
+++ b/example/apps/example-app/translations/src/en/pages.json
@@ -29,6 +29,9 @@
     "header": "What are the details of your complaint?",
     "intro": "Briefly summarise your complaint. Include anything that can help our investigation."
   },
+  "country-select": {
+    "header": "What country is your address located?"
+  },
   "confirm": {
     "header": "Check your answers before submitting your application.",
     "sections": {

--- a/example/apps/example-app/translations/src/en/pages.json
+++ b/example/apps/example-app/translations/src/en/pages.json
@@ -52,6 +52,9 @@
       },
       "complaintDetails": {
         "header": "Complaint details"
+      },
+      "countrySelect": {
+        "header": "Country"
       }
     }
   },

--- a/example/apps/example-app/translations/src/en/pages.json
+++ b/example/apps/example-app/translations/src/en/pages.json
@@ -54,7 +54,7 @@
         "header": "Complaint details"
       },
       "countrySelect": {
-        "header": "Country"
+        "header": "Country of Residence"
       }
     }
   },

--- a/example/apps/example-app/translations/src/en/validation.json
+++ b/example/apps/example-app/translations/src/en/validation.json
@@ -39,5 +39,8 @@
   "complaintDetails": {
     "default": "Enter details about why you are making a complaint",
     "maxlength": "Keep to the 5000 character limit"
+  },
+  "countrySelect": {
+    "default": "Enter your country"
   }
 }

--- a/example/apps/example-app/translations/src/en/validation.json
+++ b/example/apps/example-app/translations/src/en/validation.json
@@ -41,6 +41,6 @@
     "maxlength": "Keep to the 5000 character limit"
   },
   "countrySelect": {
-    "default": "Enter your country"
+    "default": "Enter your country of residence"
   }
 }

--- a/example/assets/js/index.js
+++ b/example/assets/js/index.js
@@ -1,2 +1,68 @@
 
 require('../../../frontend/themes/gov-uk/client-js');
+
+var $ = require('jquery');
+var typeahead = require('typeahead-aria');
+var Bloodhound = require('typeahead-aria').Bloodhound;
+
+typeahead.loadjQueryPlugin();
+
+$('.typeahead').each(function applyTypeahead() {
+  var $el = $(this);
+  var $parent = $el.parent();
+  var attributes = $el.prop('attributes');
+  var $input = $('<input/>');
+  var selectedValue = $el.val();
+  var typeaheadList = $el.find('option').map(function mapOptions() {
+    if (this.value === '') {
+      return undefined;
+    }
+    return this.value;
+  }).get();
+
+  // remove the selectbox
+  $el.remove();
+
+  $.each(attributes, function applyAttributes() {
+    $input.attr(this.name, this.value);
+  });
+
+  $input.removeClass('js-hidden');
+  $input.addClass('form-control');
+  $input.val(selectedValue);
+
+  $parent.append($input);
+
+  $input.typeahead({
+    hint: false
+  }, {
+    source: new Bloodhound({
+      datumTokenizer: Bloodhound.tokenizers.whitespace,
+      queryTokenizer: Bloodhound.tokenizers.whitespace,
+      local: typeaheadList,
+      sorter: function sorter(a, b) {
+        var input = $input.val();
+        var startsWithInput = function startsWithInput(x) {
+          return x.toLowerCase().substr(0, input.length) === input.toLowerCase() ? -1 : 1;
+        };
+
+        var compareAlpha = function compareAlpha(x, y) {
+          var less = x < y ? -1 : 1;
+          return x === y ? 0 : less;
+        };
+
+        var compareStartsWithInput = function compareStartsWithInput(x, y) {
+          var startsWithFirst = startsWithInput(x);
+          var startsWithSecond = startsWithInput(y);
+
+          return startsWithFirst === startsWithSecond ? 0 : startsWithFirst;
+        };
+
+        var first = compareStartsWithInput(a, b);
+
+        return first === 0 ? compareAlpha(a, b) : first;
+      }
+    }),
+    limit: 100
+  });
+});

--- a/example/assets/js/index.js
+++ b/example/assets/js/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+'use strict'
 
 require('../../../frontend/themes/gov-uk/client-js');
 

--- a/example/assets/scss/app.scss
+++ b/example/assets/scss/app.scss
@@ -1,2 +1,27 @@
 
 @import "../../../frontend/themes/gov-uk/styles/govuk";
+
+//autocomplete styling
+.tt-menu {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    width: 65%;
+  }
+  
+  .tt-suggestion {
+    padding: 0.5em;
+  
+    &:hover,
+    &.tt-cursor {
+      color: #fff;
+      background-color: #0097cf;
+    }
+  
+    &:hover {
+      cursor: pointer;
+    }
+  }
+  
+  .twitter-typeahead {
+    width: 100%;
+  }

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,8 @@
   },
   "author": "",
   "dependencies": {
+    "jquery": "^3.6.0",
+    "typeahead-aria": "^1.0.4"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2,3 +2,14 @@
 # yarn lockfile v1
 
 
+jquery@>=1.11, jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
+typeahead-aria@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typeahead-aria/-/typeahead-aria-1.0.4.tgz#d2829cc01c0226a367627f3098a468c4e0343f00"
+  integrity sha1-0oKcwBwCJqNnYn8wmKRoxOA0PwA=
+  dependencies:
+    jquery ">=1.11"

--- a/test/example/behaviours/country-select.spec.js
+++ b/test/example/behaviours/country-select.spec.js
@@ -2,19 +2,16 @@
 
 const Behaviour = require('../../../example/apps/example-app/behaviours/country-select');
 const homeOfficeCountries = [''].concat(require('homeoffice-countries').allCountries);
-const Controller = require('../../../controller')
+const Controller = require('../../../controller');
 const _ = require('lodash');
 
-describe.only('apps/example-app/behaviours/country-select', () => {
-  let controller
+describe('apps/example-app/behaviours/country-select', () => {
+  let controller;
   let req;
   let res;
 
   beforeEach(() => {
     req = hof_request();
-
-    let sandbox;
-    sandbox = sinon.createSandbox();
 
     req.form.options = {fields: {
       countrySelect: {
@@ -23,19 +20,18 @@ describe.only('apps/example-app/behaviours/country-select', () => {
         }
       }
     }};
-    const CountrySelectController = Behaviour(Controller)
-    controller = new CountrySelectController({})
-
+    const CountrySelectController = Behaviour(Controller);
+    controller = new CountrySelectController({});
   });
 
   describe('countryselect', () => {
     it('checks to see if all country options labels contain country list in its fields', () => {
       controller.configure(req, res, () => {
-        const countryOptions = req.form.options.fields['countrySelect'].options;
+        const countryOptions = req.form.options.fields.countrySelect.options;
         const countryLabels = [''].concat(_.map(countryOptions, obj => obj.label));
-        countryLabels.concat(['Please select a country'])
-        homeOfficeCountries.splice(1 , 0, 'Please select a country')
-        countryLabels.should.deep.equal((homeOfficeCountries))
+        countryLabels.concat(['Please select a country']);
+        homeOfficeCountries.splice(1, 0, 'Please select a country');
+        countryLabels.should.deep.equal((homeOfficeCountries));
       });
     });
   });

--- a/test/example/behaviours/country-select.spec.js
+++ b/test/example/behaviours/country-select.spec.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const Behaviour = require('../../../example/apps/example-app/behaviours/country-select');
+const homeOfficeCountries = [''].concat(require('homeoffice-countries').allCountries);
+const Controller = require('../../../controller')
+console.log(Controller)
+
+
+describe.only('apps/example-app/behaviours/country-select', () => {
+  let controller
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = hof_request();
+
+    let sandbox;
+    sandbox = sinon.createSandbox();
+
+    req.form.options = {fields: {
+      countrySelect: {
+        options: {
+
+        }
+      }
+    }};
+    console.log("req: ", req.form.options)
+  
+    //sandbox.stub(Controller.protoype, 'configure').yieldsAsync();
+    const CountrySelectController = Behaviour(Controller)
+    controller = new CountrySelectController()
+
+    //req.form.options.fields.options = { // so does this
+        //'countrySelect': {
+            //value: 'Austria'
+        //}
+    //};
+
+  });
+
+  describe('countryselect', () => {
+    it('checks to see if austria is in fields', () => {
+      controller.configure(req, res, () => {
+        req.form.options.fields['countrySelect'].options.should.have.property('Austria')  
+      });
+    });
+  });
+});

--- a/test/example/behaviours/country-select.spec.js
+++ b/test/example/behaviours/country-select.spec.js
@@ -3,8 +3,7 @@
 const Behaviour = require('../../../example/apps/example-app/behaviours/country-select');
 const homeOfficeCountries = [''].concat(require('homeoffice-countries').allCountries);
 const Controller = require('../../../controller')
-console.log(Controller)
-
+const _ = require('lodash');
 
 describe.only('apps/example-app/behaviours/country-select', () => {
   let controller
@@ -24,24 +23,19 @@ describe.only('apps/example-app/behaviours/country-select', () => {
         }
       }
     }};
-    console.log("req: ", req.form.options)
-  
-    //sandbox.stub(Controller.protoype, 'configure').yieldsAsync();
     const CountrySelectController = Behaviour(Controller)
-    controller = new CountrySelectController()
-
-    //req.form.options.fields.options = { // so does this
-        //'countrySelect': {
-            //value: 'Austria'
-        //}
-    //};
+    controller = new CountrySelectController({})
 
   });
 
   describe('countryselect', () => {
-    it('checks to see if austria is in fields', () => {
+    it('checks to see if all country options labels contain country list in its fields', () => {
       controller.configure(req, res, () => {
-        req.form.options.fields['countrySelect'].options.should.have.property('Austria')  
+        const countryOptions = req.form.options.fields['countrySelect'].options;
+        const countryLabels = [''].concat(_.map(countryOptions, obj => obj.label));
+        countryLabels.concat(['Please select a country'])
+        homeOfficeCountries.splice(1 , 0, 'Please select a country')
+        countryLabels.should.deep.equal((homeOfficeCountries))
       });
     });
   });


### PR DESCRIPTION
What
Created country search select step for the complex form. Added required validation, labels and headers so it is similar to GRO. Added country select on summary page.
Added two dependencies via yarn:
jquery
typeahead-aria

Why
User can explore the search select component that is found in GRO.