### PR TITLE
HOFF-213 continue saved form step

### DIFF
--- a/example/apps/example-app/fields.js
+++ b/example/apps/example-app/fields.js
@@ -102,5 +102,26 @@ module.exports = {
       value: '',
       label: 'fields.appealStages.options.null'
     }].concat(staticAppealStages.getstaticAppealStages())
+  },
+  continueSavedForms: {
+    mixin: 'radio-group',
+    validate: ['required'],
+    legend: {
+      className: 'visuallyhidden'
+    },
+    options: [{
+      value: 'yes',
+      toggle: 'savedFormEmail',
+      child: 'partials/saved-form-email'
+    }, {
+      value: 'no'
+    }]
+  },
+  savedFormEmail: {
+    validate: ['email', 'required'],
+    dependent: {
+      field: 'continueSavedForms',
+      value: 'yes'
+    }
   }
 }

--- a/example/apps/example-app/index.js
+++ b/example/apps/example-app/index.js
@@ -13,13 +13,22 @@ module.exports = {
         'landing-page-radio'
       ],
       next: '/name',
-      forks: [{
-        target: '/build-your-own-form',
-        condition: {
-          field: 'landing-page-radio',
-          value: 'build-your-own-form'
+      forks: [
+        {
+          target: '/build-your-own-form',
+          condition: {
+            field: 'landing-page-radio',
+            value: 'build-your-own-form'
+          }
+        },
+        {
+          target: '/continue-saved-form',
+          condition: {
+            field: 'landing-page-radio',
+            value: 'complex-form'
+          }
         }
-      }],
+      ],
     },
     '/build-your-own-form': {
       template: 'form-guidance-link'
@@ -87,5 +96,23 @@ module.exports = {
       ],
       next: '/confirm'
     },
+    '/continue-saved-form':{
+      template: 'continue-saved-forms',
+      fields: [
+        'continueSavedForms',
+        'savedFormEmail'
+      ],
+      next: '/forms',
+      forks: [{
+        target: '/name',
+        condition: {
+          field: 'continueSavedForms',
+          value: 'no'
+        }
+      }]
+    },
+    '/forms':{
+
+    }
   }
 };

--- a/example/apps/example-app/index.js
+++ b/example/apps/example-app/index.js
@@ -97,7 +97,7 @@ module.exports = {
       next: '/confirm'
     },
     '/continue-saved-form':{
-      template: 'continue-saved-forms',
+      template: 'continue-saved-form',
       fields: [
         'continueSavedForms',
         'savedFormEmail'

--- a/example/apps/example-app/translations/src/en/fields.json
+++ b/example/apps/example-app/translations/src/en/fields.json
@@ -90,5 +90,18 @@
     "options": {
       "null": "Select..."
     }
+  },
+  "continueSavedForms": {
+    "options":{
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "savedFormEmail": {
+    "label": "What email did you use to save the form"
   }
 }

--- a/example/apps/example-app/translations/src/en/fields.json
+++ b/example/apps/example-app/translations/src/en/fields.json
@@ -102,6 +102,7 @@
     }
   },
   "savedFormEmail": {
-    "label": "What email did you use to save the form"
+    "label": "Enter the email address used to save the form",
+    "hint": "Email address"
   }
 }

--- a/example/apps/example-app/translations/src/en/pages.json
+++ b/example/apps/example-app/translations/src/en/pages.json
@@ -71,5 +71,8 @@
     "alert": "Application sent", 
     "subheader": "What happens next",
     "content": "We’ll contact you with the decision of your application or if we need more information from you."
+  },
+  "continue-saved-form": {
+    "header": "Do you want to continue a previously saved form"
   }
 }

--- a/example/apps/example-app/translations/src/en/pages.json
+++ b/example/apps/example-app/translations/src/en/pages.json
@@ -73,6 +73,6 @@
     "content": "We’ll contact you with the decision of your application or if we need more information from you."
   },
   "continue-saved-form": {
-    "header": "Do you want to continue a previously saved form"
+    "header": "Do you want to continue a saved form?"
   }
 }

--- a/example/apps/example-app/translations/src/en/validation.json
+++ b/example/apps/example-app/translations/src/en/validation.json
@@ -46,5 +46,11 @@
   },
   "appealStages": {
     "required": "Select an appeal stage from the list"
+  },
+  "continueSavedForms": {
+    "required": "Do you want to continue a form you have previously saved?"
+  },
+  "savedFormEmail": { 
+    "default": "Enter the email address used to save the form in the correct format"
   }
 }

--- a/example/apps/example-app/views/continue-saved-form.html
+++ b/example/apps/example-app/views/continue-saved-form.html
@@ -1,9 +1,7 @@
 {{<partials-page}}
   {{$page-content}}
 
-    {{#fields}}
-      {{#renderField}}{{/renderField}}
-    {{/fields}}
+    {{#renderField}}continueSavedForms{{/renderField}}
 
     {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}

--- a/example/apps/example-app/views/continue-saved-forms.html
+++ b/example/apps/example-app/views/continue-saved-forms.html
@@ -1,0 +1,10 @@
+{{<partials-page}}
+  {{$page-content}}
+
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/example/apps/example-app/views/partials/saved-form-email.html
+++ b/example/apps/example-app/views/partials/saved-form-email.html
@@ -1,0 +1,5 @@
+<div id="{{toggle}}-panel" class="reveal" aria-hidden="false">
+  <div class="panel-indent">
+    {{#input-text}}{{toggle}}{{/input-text}}
+  </div>
+</div>

--- a/example/test/_features/example_app/complex_form.feature
+++ b/example/test/_features/example_app/complex_form.feature
@@ -2,10 +2,13 @@
 Feature: Complex Form
   A user should select complex form on the landing page
 
-  Scenario: Complex Form Submission
+  Scenario: Complex Form Submission without continuing a previously saved form
     Given I start the 'base' application journey
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
     Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I should be on the 'continue-saved-form' page showing 'Do you want to continue a saved form?'
+    Then I choose 'No'
     Then I continue to the next step
     Then I should be on the 'name' page showing 'What is your full name?'
     Then I fill 'name' with 'Jane Doe'
@@ -40,3 +43,16 @@ Feature: Complex Form
     Then I should see 'Application sent' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+  
+  @continue-saved-form continuing a saved form
+  Scenario: Complex form submission
+    Given I start the 'base' application journey
+    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+    Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I should be on the 'continue-saved-form' page showing 'Do you want to continue a saved form?'
+    Then I choose 'Yes'
+    Then I fill 'savedFormEmail' with 'email@test.com'
+    Then I continue to the next step
+
+

--- a/example/test/_features/example_app/complex_form.feature
+++ b/example/test/_features/example_app/complex_form.feature
@@ -2,7 +2,7 @@
 Feature: Complex Form
   A user should select complex form on the landing page
 
-  Scenario: Complex Form Submission without continuing a previously saved form
+  Scenario: Complex Form Submission Without Continuing A Saved Form
     Given I start the 'base' application journey
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
     Then I choose 'Complex form'
@@ -44,8 +44,8 @@ Feature: Complex Form
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
   
-  @continue-saved-form continuing a saved form
-  Scenario: Complex form submission
+  @continue-saved-form 
+  Scenario: Complex Form Submission Continuing A Saved Form
     Given I start the 'base' application journey
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
     Then I choose 'Complex form'

--- a/example/test/_features/example_app/validation.feature
+++ b/example/test/_features/example_app/validation.feature
@@ -130,7 +130,7 @@ Feature: validations
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
 
   @complex_form @continue-saved-form
-  Scenario: Full Basic Form Submission
+  Scenario: Partial Complex Form Submission Continuing A Saved Form
     Given I start the 'base' application journey
     Given I start the 'base' application journey
     Then I continue to the next step

--- a/example/test/_features/example_app/validation.feature
+++ b/example/test/_features/example_app/validation.feature
@@ -62,6 +62,7 @@ Feature: validations
     Then I should see 'Application sent' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+
   @complex_form
   Scenario: Full Complex Form Submission
     Given I start the 'base' application journey
@@ -69,7 +70,11 @@ Feature: validations
     Then I should see the 'Select an option below and press continue' error
     Then I choose 'Complex form'
     Then I continue to the next step
-    Then I click the 'Continue' button
+    Then I continue to the next step
+    Then I should see the 'Do you want to continue a form you have previously saved?' error
+    Then I choose 'No'
+    Then I continue to the next step
+    Then I continue to the next step
     Then I should see the 'Enter your full name' error
     Then I fill 'name' with 'Jane Doe'
     Then I click the 'Continue' button
@@ -123,3 +128,17 @@ Feature: validations
     Then I should see 'Application sent' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+
+  @complex_form @continue-saved-form
+  Scenario: Full Basic Form Submission
+    Given I start the 'base' application journey
+    Given I start the 'base' application journey
+    Then I continue to the next step
+    Then I should see the 'Select an option below and press continue' error
+    Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I continue to the next step
+    Then I should see the 'Do you want to continue a form you have previously saved?' error
+    Then I choose 'Yes'
+    Then I continue to the next step
+    Then I should see the 'Enter the email address used to save the form in the correct format' error


### PR DESCRIPTION
**What?**

Add continue-saved-form step to the complex form demo, as part of incorporating a demo to the example app. The page asks the user if they want to continue a form they saved previously. 

**Why**

Enable the user to eventually go back to a saved form saved under that email address.

