### PR TITLE
HOF-25 - Added sanitsation middleware and appropriate tests

### DIFF
--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -38,16 +38,17 @@ const defaults = {
   },
   serveStatic: process.env.SERVE_STATIC_FILES !== 'false',
   sanitisationBlacklistArray: {
-    //Input will be sanitised using the below rules
-    //The key is what we're sanitising out
-    //The regex is the rule we used to find them (note some dictate repeating characters)
-    //And the replace is what we're replacing that pattern with. Usually nothing sometimes a single character or sometimes a single character followed by a "-"
+    // Input will be sanitised using the below rules
+    // The key is what we're sanitising out
+    // The regex is the rule we used to find them (note some dictate repeating characters)
+    // And the replace is what we're replacing that pattern with. Usually nothing sometimes a
+    // single character or sometimes a single character followed by a "-"
     '/*': { regex: '\/\\*', replace: '' },
     '*/': { regex: '\\*\\/', replace: '' },
     '|': { regex: '\\|', replace: '' },
     '&&': { regex: '&&+', replace: '&' },
     '@@': { regex: '@@+', replace: '@' },
-    '/..;/': { regex: '/\\.\\.;/', replace: '' }, //Purposely input before ".." as they conflict
+    '/..;/': { regex: '/\\.\\.;/', replace: '' }, // Purposely input before ".." as they conflict
     '..': { regex: '\\.\\.+', replace: '.' },
     '/etc/passwd': { regex: '\/etc\/passwd', replace: '' },
     'c:\\': { regex: 'c:\\\\', replace: '' },

--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -36,7 +36,30 @@ const defaults = {
   apis: {
     pdfConverter: process.env.PDF_CONVERTER_URL
   },
-  serveStatic: process.env.SERVE_STATIC_FILES !== 'false'
+  serveStatic: process.env.SERVE_STATIC_FILES !== 'false',
+  sanitisationBlacklistArray: {
+    //Input will be sanitised using the below rules
+    //The key is what we're sanitising out
+    //The regex is the rule we used to find them (note some dictate repeating characters)
+    //And the replace is what we're replacing that pattern with. Usually nothing sometimes a single character or sometimes a single character followed by a "-"
+    '/*': { regex: '\/\\*', replace: '' },
+    '*/': { regex: '\\*\\/', replace: '' },
+    '|': { regex: '\\|', replace: '' },
+    '&&': { regex: '&&+', replace: '&' },
+    '@@': { regex: '@@+', replace: '@' },
+    '/..;/': { regex: '/\\.\\.;/', replace: '' }, //Purposely input before ".." as they conflict
+    '..': { regex: '\\.\\.+', replace: '.' },
+    '/etc/passwd': { regex: '\/etc\/passwd', replace: '' },
+    'c:\\': { regex: 'c:\\\\', replace: '' },
+    'cmd.exe': { regex: 'cmd\\.exe', replace: '' },
+    '<': { regex: '<', replace: '<-' },
+    '>': { regex: '>', replace: '>-' },
+    '[': { regex: '\\[+', replace: '[-' },
+    ']': { regex: '\\]+', replace: ']-' },
+    '~': { regex: '~', replace: '~-' },
+    '&#': { regex: '&#', replace: '&#-' },
+    '%U': { regex: '%U', replace: '%U-' }
+  }
 };
 
 module.exports = defaults;

--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -36,31 +36,7 @@ const defaults = {
   apis: {
     pdfConverter: process.env.PDF_CONVERTER_URL
   },
-  serveStatic: process.env.SERVE_STATIC_FILES !== 'false',
-  sanitisationBlacklistArray: {
-    // Input will be sanitised using the below rules
-    // The key is what we're sanitising out
-    // The regex is the rule we used to find them (note some dictate repeating characters)
-    // And the replace is what we're replacing that pattern with. Usually nothing sometimes a
-    // single character or sometimes a single character followed by a "-"
-    '/*': { regex: '\/\\*', replace: '' },
-    '*/': { regex: '\\*\\/', replace: '' },
-    '|': { regex: '\\|', replace: '' },
-    '&&': { regex: '&&+', replace: '&' },
-    '@@': { regex: '@@+', replace: '@' },
-    '/..;/': { regex: '/\\.\\.;/', replace: '' }, // Purposely input before ".." as they conflict
-    '..': { regex: '\\.\\.+', replace: '.' },
-    '/etc/passwd': { regex: '\/etc\/passwd', replace: '' },
-    'c:\\': { regex: 'c:\\\\', replace: '' },
-    'cmd.exe': { regex: 'cmd\\.exe', replace: '' },
-    '<': { regex: '<', replace: '<-' },
-    '>': { regex: '>', replace: '>-' },
-    '[': { regex: '\\[+', replace: '[-' },
-    ']': { regex: '\\]+', replace: ']-' },
-    '~': { regex: '~', replace: '~-' },
-    '&#': { regex: '&#', replace: '&#-' },
-    '%U': { regex: '%U', replace: '%U-' }
-  }
+  serveStatic: process.env.SERVE_STATIC_FILES !== 'false'
 };
 
 module.exports = defaults;

--- a/config/sanitisation-rules.js
+++ b/config/sanitisation-rules.js
@@ -1,0 +1,29 @@
+'use strict';
+/* eslint no-process-env: "off" */
+
+const sanitisationBlacklistArray = {
+    // Input will be sanitised using the below rules
+    // The key is what we're sanitising out
+    // The regex is the rule we used to find them (note some dictate repeating characters)
+    // And the replace is what we're replacing that pattern with. Usually nothing sometimes a
+    // single character or sometimes a single character followed by a "-"
+    '/*': { regex: '\/\\*', replace: '' },
+    '*/': { regex: '\\*\\/', replace: '' },
+    '|': { regex: '\\|', replace: '' },
+    '&&': { regex: '&&+', replace: '&' },
+    '@@': { regex: '@@+', replace: '@' },
+    '/..;/': { regex: '/\\.\\.;/', replace: '' }, // Purposely input before ".." as they conflict
+    '..': { regex: '\\.\\.+', replace: '.' },
+    '/etc/passwd': { regex: '\/etc\/passwd', replace: '' },
+    'c:\\': { regex: 'c:\\\\', replace: '' },
+    'cmd.exe': { regex: 'cmd\\.exe', replace: '' },
+    '<': { regex: '<', replace: '<-' },
+    '>': { regex: '>', replace: '>-' },
+    '[': { regex: '\\[+', replace: '[-' },
+    ']': { regex: '\\]+', replace: ']-' },
+    '~': { regex: '~', replace: '~-' },
+    '&#': { regex: '&#', replace: '&#-' },
+    '%U': { regex: '%U', replace: '%U-' }
+};
+
+module.exports = sanitisationBlacklistArray;

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -8,7 +8,7 @@ const debug = require('debug')('hmpo:form');
 const dataFormatter = require('./formatting');
 const dataValidator = require('./validation');
 const ErrorClass = require('./validation-error');
-const defaults = require('../config/hof-defaults');
+const sanitisationBlacklistArray = require('../config/sanitisation-rules');
 
 module.exports = class BaseController extends EventEmitter {
   constructor(options) {
@@ -167,8 +167,8 @@ module.exports = class BaseController extends EventEmitter {
   _sanitize(req, res, callback) {
     Object.keys(req.form.values).forEach(function(property,propertyIndex) {
       // For each property in our form data
-      Object.keys(defaults.sanitisationBlacklistArray).forEach(function(blacklisted,blacklistedIndex) {
-        const blacklistedDetail = defaults.sanitisationBlacklistArray[blacklisted];
+      Object.keys(sanitisationBlacklistArray).forEach(function(blacklisted,blacklistedIndex) {
+        const blacklistedDetail = sanitisationBlacklistArray[blacklisted];
         const regexQuery = new RegExp(blacklistedDetail.regex, 'gi');
         // Will perform the required replace based on our passed in regex and the replace string
         req.form.values[property] = req.form.values[property].replace(regexQuery, blacklistedDetail.replace);

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -165,18 +165,15 @@ module.exports = class BaseController extends EventEmitter {
   }
 
   _sanitize(req, res, callback) {
-    for(var property in req.form.values)
-    {
-        //For each property in our form data
-        for(let blacklisted in defaults.sanitisationBlacklistArray) {
-          let blacklistedDetail = defaults.sanitisationBlacklistArray[blacklisted];
-          var regexQuery = new RegExp(blacklistedDetail.regex, "gi");
-          //Remove duplicates and add the hyphen
-          console.log('Before: ' + req.form.values[property]);
-          req.form.values[property] = req.form.values[property].replace(regexQuery, blacklistedDetail.replace);
-          console.log('After: ' + req.form.values[property]);
-        }
-    }
+    Object.keys(req.form.values).forEach(function(property,propertyIndex) {
+      // For each property in our form data
+      Object.keys(defaults.sanitisationBlacklistArray).forEach(function(blacklisted,blacklistedIndex) {
+        const blacklistedDetail = defaults.sanitisationBlacklistArray[blacklisted];
+        const regexQuery = new RegExp(blacklistedDetail.regex, 'gi');
+        // Will perform the required replace based on our passed in regex and the replace string
+        req.form.values[property] = req.form.values[property].replace(regexQuery, blacklistedDetail.replace);
+      });
+    });
     callback();
   }
 

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -8,6 +8,7 @@ const debug = require('debug')('hmpo:form');
 const dataFormatter = require('./formatting');
 const dataValidator = require('./validation');
 const ErrorClass = require('./validation-error');
+const defaults = require('../config/hof-defaults');
 
 module.exports = class BaseController extends EventEmitter {
   constructor(options) {
@@ -69,6 +70,7 @@ module.exports = class BaseController extends EventEmitter {
         this._configure.bind(this),
         this._process.bind(this),
         this._validate.bind(this),
+        this._sanitize.bind(this),
         this._getHistoricalValues.bind(this),
         this.saveValues.bind(this),
         this.successHandler.bind(this),
@@ -160,6 +162,22 @@ module.exports = class BaseController extends EventEmitter {
     const validator = vld || dataValidator(req.form.options.fields);
     const emptyValue = formatter(key, '');
     return validator(key, req.form.values[key], req.form.values, emptyValue);
+  }
+
+  _sanitize(req, res, callback) {
+    for(var property in req.form.values)
+    {
+        //For each property in our form data
+        for(let blacklisted in defaults.sanitisationBlacklistArray) {
+          let blacklistedDetail = defaults.sanitisationBlacklistArray[blacklisted];
+          var regexQuery = new RegExp(blacklistedDetail.regex, "gi");
+          //Remove duplicates and add the hyphen
+          console.log('Before: ' + req.form.values[property]);
+          req.form.values[property] = req.form.values[property].replace(regexQuery, blacklistedDetail.replace);
+          console.log('After: ' + req.form.values[property]);
+        }
+    }
+    callback();
   }
 
   _process(req, res, callback) {

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -519,12 +519,26 @@ describe('Form Controller', () => {
 
     describe('sanitise inputs', () => {
       const tests = [
-        { value: 'HELLO/..;/WORLD', expected: 'HELLOWORLD' },
+        { value: 'HELLO\/*TEST*\/WORLD1', expected: 'HELLOTESTWORLD1' },
+        { value: 'HELLO|WORLD2', expected: 'HELLOWORLD2' },
+        { value: 'HELLO&&WORLD3', expected: 'HELLO&WORLD3' },
+        { value: 'HELLO@@WORLD4', expected: 'HELLO@WORLD4' },
+        { value: 'HELLO/..;/WORLD5', expected: 'HELLOWORLD5' },
+        { value: 'HELLO......WORLD6', expected: 'HELLO.WORLD6' },
+        { value: 'HELLO/eTc/paSsWdWORLD7', expected: 'HELLOWORLD7' },
+        { value: 'HELLOC:\\WORLD8', expected: 'HELLOWORLD8' },
+        { value: 'HELLOcMd.ExEWORLD9', expected: 'HELLOWORLD9' },
+        { value: 'HELLO<WORLD10', expected: 'HELLO<-WORLD10' },
+        { value: 'HELLO>WORLD11', expected: 'HELLO>-WORLD11' },
+        { value: 'HELLO[WORLD12', expected: 'HELLO[-WORLD12' },
+        { value: 'HELLO]WORLD13', expected: 'HELLO]-WORLD13' },
+        { value: 'HELLO~WORLD14', expected: 'HELLO~-WORLD14' },
+        { value: 'HELLO&#WORLD15', expected: 'HELLO&#-WORLD15' },
+        { value: 'HELLO%UWORLD16', expected: 'HELLO%U-WORLD16' },
         {
           value: '1/*2*/3|4&&5@@6..7/etc/PASSwd8C:\\9Cmd.eXe10/..;/11<12>13[14]15~16&#17%U18',
           expected: '1234&5@6.7891011<-12>-13[-14]-15~-16&#-17%U-18'
-        },
-        { value: '@@ABC123', expected: '@ABC123' }
+        }
       ];
 
       tests.forEach(({value, expected}) => {

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -517,6 +517,26 @@ describe('Form Controller', () => {
       form.validate.should.have.been.calledOn(form);
     });
 
+    describe.only('sanitise inputs', () => {
+      const tests = [
+        {value: "HELLO/..;/WORLD", expected: "HELLOWORLD"},
+        {value: "1/*2*/3|4&&5@@6..7/etc/PASSwd8C:\\9Cmd.eXe10/..;/11<12>13[14]15~16&#17%U18", expected: "1234&5@6.7891011<-12>-13[-14]-15~-16&#-17%U-18"},
+        {value: "@@ABC123", expected: "@ABC123"},
+      ];
+
+      tests.forEach(({value, expected}) => {
+        it(`sanitisation returns correct data`, function () {
+          req.form = {
+            values: {
+              value: value,
+            }
+          };
+          form._sanitize(req, res, cb);
+          req.form.values.value.should.equal(expected);
+        });
+      });
+    });
+
     describe('valid inputs', () => {
       it('calls form.saveValues', () => {
         form.post(req, res, cb);

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -538,7 +538,12 @@ describe('Form Controller', () => {
         {
           value: '1/*2*/3|4&&5@@6..7/etc/PASSwd8C:\\9Cmd.eXe10/..;/11<12>13[14]15~16&#17%U18',
           expected: '1234&5@6.7891011<-12>-13[-14]-15~-16&#-17%U-18'
-        }
+        },
+        { value: 'Test User', expected: 'Test User'},
+        { value: '123 Test Street', expected: '123 Test Street'},
+        { value: 'London', expected: 'London'},
+        { value: 'United Kingdom', expected: 'United Kingdom'},
+        { value: '2022-01-01', expected: '2022-01-01' }
       ];
 
       tests.forEach(({value, expected}) => {

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -517,18 +517,21 @@ describe('Form Controller', () => {
       form.validate.should.have.been.calledOn(form);
     });
 
-    describe.only('sanitise inputs', () => {
+    describe('sanitise inputs', () => {
       const tests = [
-        {value: "HELLO/..;/WORLD", expected: "HELLOWORLD"},
-        {value: "1/*2*/3|4&&5@@6..7/etc/PASSwd8C:\\9Cmd.eXe10/..;/11<12>13[14]15~16&#17%U18", expected: "1234&5@6.7891011<-12>-13[-14]-15~-16&#-17%U-18"},
-        {value: "@@ABC123", expected: "@ABC123"},
+        { value: 'HELLO/..;/WORLD', expected: 'HELLOWORLD' },
+        {
+          value: '1/*2*/3|4&&5@@6..7/etc/PASSwd8C:\\9Cmd.eXe10/..;/11<12>13[14]15~16&#17%U18',
+          expected: '1234&5@6.7891011<-12>-13[-14]-15~-16&#-17%U-18'
+        },
+        { value: '@@ABC123', expected: '@ABC123' }
       ];
 
       tests.forEach(({value, expected}) => {
-        it(`sanitisation returns correct data`, function () {
+        it('sanitisation returns correct data', function () {
           req.form = {
             values: {
-              value: value,
+              value: value
             }
           };
           form._sanitize(req, res, cb);


### PR DESCRIPTION
What?
In order to move away from using naxsi rules we need to sanitise the user input before saving it to session

Why?
Naxsi is a sledgehammer which we've had to disable many rules so our users don't get problems. Instead we're going to add new sanitisation rules that will manipulate the user input if they enter something we don't like to avoid possible SQL injection and other attacks.

How?
Added a new middleware in the base-controller called _sanitization() which will loop our user inputs and modify them accrdingly.

Testing?
Unit tests and linting tests.

Screenshots (optional)
N/A

Anything Else?
Rules for what we have agreed to do for each unwanted string are detailed on the original ticket - HOF-25.