### PR TITLE
Setup session rate limits

### DIFF
--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -1,5 +1,6 @@
 'use strict';
 /* eslint no-process-env: "off" */
+const rateLimits = require('./rate-limits');
 
 const defaults = {
   appName: process.env.APP_NAME || 'HOF Application',
@@ -40,4 +41,4 @@ const defaults = {
   serveStatic: process.env.SERVE_STATIC_FILES !== 'false'
 };
 
-module.exports = defaults;
+module.exports = Object.assign({}, defaults, rateLimits);

--- a/config/rate-limits.js
+++ b/config/rate-limits.js
@@ -1,0 +1,20 @@
+
+module.exports = {
+  rateLimits: {
+    env: process.env.NODE_ENV,
+    requests: {
+      active: false,
+      windowSizeInMinutes: 5,
+      maxWindowRequestCount: 100,
+      windowLogIntervalInMinutes: 1,
+      errCode: 'DDOS_RATE_LIMIT'
+    },
+    submissions: {
+      active: false,
+      windowSizeInMinutes: 10,
+      maxWindowRequestCount: 1,
+      windowLogIntervalInMinutes: 1,
+      errCode: 'SUBMISSION_RATE_LIMIT'
+    }
+  }
+};

--- a/frontend/template-partials/translations/src/en/errors.json
+++ b/frontend/template-partials/translations/src/en/errors.json
@@ -17,10 +17,14 @@
   },
   "ddos-rate-limit": {
     "title": "Too many requests submitted",
-    "message": "You have submitted too many requests in quick succession. Please try again in a few minutes."
+    "message": "You have submitted too many requests in quick succession.",
+    "pre-time-to-wait": "Please try again in ",
+    "post-time-to-wait": " minutes."
   },
   "submission-rate-limit": {
     "title": "Too many submissions",
-    "message": "You have submitted too many applications in a short space of time. Please try again in a few minutes."
+    "message": "You have submitted too many applications in a short space of time.",
+    "pre-time-to-wait": "Please try again in ",
+    "post-time-to-wait": " minutes."
   }
 }

--- a/frontend/template-partials/translations/src/en/errors.json
+++ b/frontend/template-partials/translations/src/en/errors.json
@@ -14,5 +14,13 @@
   "cookies-required": {
     "title": "Cookies are required to use this service",
     "message": "Cookies are required in order to use this service.<br /><br /> Please <a href=\"http://www.aboutcookies.org/how-to-control-cookies/\" rel=\"external\">enable cookies</a> and try again. Find out <a href=\"/cookies\">how to we use cookies</a>."
+  },
+  "ddos-rate-limit": {
+    "title": "Too many requests submitted",
+    "message": "You have submitted too many requests in quick succession. Please try again in a few minutes."
+  },
+  "submission-rate-limit": {
+    "title": "Too many submissions",
+    "message": "You have submitted too many applications in a short space of time. Please try again in a few minutes."
   }
 }

--- a/frontend/template-partials/views/rate-limit-error.html
+++ b/frontend/template-partials/views/rate-limit-error.html
@@ -1,0 +1,9 @@
+{{<layout}}
+  {{$header}}
+    {{content.title}}
+  {{/header}}
+  {{$content}}
+    <p>{{content.message}}</p>
+    <a href="/" class="button" role="button">{{#t}}buttons.try-again{{/t}}</a>
+  {{/content}}
+{{/layout}}

--- a/frontend/template-partials/views/rate-limit-error.html
+++ b/frontend/template-partials/views/rate-limit-error.html
@@ -4,6 +4,7 @@
   {{/header}}
   {{$content}}
     <p>{{content.message}}</p>
+    <p>{{content.preTimeToWait}}{{content.timeToWait}}{{content.postTimeToWait}}</p>
     <a href="/" class="button" role="button">{{#t}}buttons.try-again{{/t}}</a>
   {{/content}}
 {{/layout}}

--- a/index.js
+++ b/index.js
@@ -204,6 +204,10 @@ function bootstrap(options) {
   }));
   app.use(mixins());
   app.use(markdown(config.markdown));
+  // rate limits have to be loaded before all routes so it is applied to them
+  if (config.rateLimits.requests.active) {
+    app.use(hofMiddleware.rateLimiter(config, 'requests'));
+  }
 
   if (config.getAccessibility === true) {
     deprecate(

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -21,6 +21,24 @@ const getContent = (err, translate) => {
     content.message = (translate && translate('errors.cookies-required.message'));
   }
 
+  if (err.code === 'DDOS_RATE_LIMIT') {
+    err.status = 429;
+    err.template = 'rate-limit-error';
+    err.title = (translate && translate('errors.ddos-rate-limit.title'));
+    err.message = (translate && translate('errors.ddos-rate-limit.message'));
+    content.title = (translate && translate('errors.ddos-rate-limit.title'));
+    content.message = (translate && translate('errors.ddos-rate-limit.message'));
+  }
+
+  if (err.code === 'SUBMISSION_RATE_LIMIT') {
+    err.status = 429;
+    err.template = 'rate-limit-error';
+    err.title = (translate && translate('errors.submission-rate-limit.title'));
+    err.message = (translate && translate('errors.submission-rate-limit.message'));
+    content.title = (translate && translate('errors.submission-rate-limit.title'));
+    content.message = (translate && translate('errors.submission-rate-limit.message'));
+  }
+
   err.code = err.code || 'UNKNOWN';
   err.status = err.status || 500;
 

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-unused-vars */
 'use strict';
 
+const rateLimitsConfig = require('../config/rate-limits');
+
 const errorTitle = code => `${code}_ERROR`;
 const errorMsg = code => `There is a ${code}_ERROR`;
 // eslint-disable-next-line complexity
@@ -26,8 +28,14 @@ const getContent = (err, translate) => {
     err.template = 'rate-limit-error';
     err.title = (translate && translate('errors.ddos-rate-limit.title'));
     err.message = (translate && translate('errors.ddos-rate-limit.message'));
+    err.preTimeToWait = (translate && translate('errors.ddos-rate-limit.pre-time-to-wait'));
+    err.timeToWait = rateLimitsConfig.rateLimits.requests.windowSizeInMinutes;
+    err.postTimeToWait = (translate && translate('errors.ddos-rate-limit.post-time-to-wait'));
     content.title = (translate && translate('errors.ddos-rate-limit.title'));
     content.message = (translate && translate('errors.ddos-rate-limit.message'));
+    content.preTimeToWait = (translate && translate('errors.ddos-rate-limit.pre-time-to-wait'));
+    content.timeToWait = rateLimitsConfig.rateLimits.requests.windowSizeInMinutes;
+    content.postTimeToWait = (translate && translate('errors.ddos-rate-limit.post-time-to-wait'));
   }
 
   if (err.code === 'SUBMISSION_RATE_LIMIT') {
@@ -35,8 +43,14 @@ const getContent = (err, translate) => {
     err.template = 'rate-limit-error';
     err.title = (translate && translate('errors.submission-rate-limit.title'));
     err.message = (translate && translate('errors.submission-rate-limit.message'));
+    err.preTimeToWait = (translate && translate('errors.submission-rate-limit.pre-time-to-wait'));
+    err.timeToWait = rateLimitsConfig.rateLimits.submissions.windowSizeInMinutes;
+    err.postTimeToWait = (translate && translate('errors.submission-rate-limit.post-time-to-wait'));
     content.title = (translate && translate('errors.submission-rate-limit.title'));
     content.message = (translate && translate('errors.submission-rate-limit.message'));
+    content.preTimeToWait = (translate && translate('errors.submission-rate-limit.pre-time-to-wait'));
+    content.timeToWait = rateLimitsConfig.rateLimits.submissions.windowSizeInMinutes;
+    content.postTimeToWait = (translate && translate('errors.submission-rate-limit.post-time-to-wait'));
   }
 
   err.code = err.code || 'UNKNOWN';

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -4,5 +4,6 @@ module.exports = {
   cookies: require('./cookies'),
   errors: require('./errors'),
   notFound: require('./not-found'),
-  deepTranslate: require('./deep-translate')
+  deepTranslate: require('./deep-translate'),
+  rateLimiter: require('./rate-limiter')
 };

--- a/middleware/rate-limiter.js
+++ b/middleware/rate-limiter.js
@@ -39,8 +39,8 @@ module.exports = (options, rateLimitType) => {
         }
 
         if (!record || oldRecord) {
-          let newRecord = [];
-          let requestLog = {
+          const newRecord = [];
+          const requestLog = {
             [timestampName]: currentRequestTime.unix(),
             [countName]: 1
           };
@@ -49,23 +49,24 @@ module.exports = (options, rateLimitType) => {
           return next();
         }
         // if record is found, parse it's value and calculate number of requests users has made within the last window
-        let requestsWithinWindow = data.filter(entry => entry[timestampName] > windowStartTimestamp);
+        const requestsWithinWindow = data.filter(entry => entry[timestampName] > windowStartTimestamp);
 
-        let totalWindowRequestsCount = requestsWithinWindow.reduce((accumulator, entry) => {
+        const totalWindowRequestsCount = requestsWithinWindow.reduce((accumulator, entry) => {
           return accumulator + entry[countName];
         }, 0);
 
         if (!options.rateLimits.env || options.rateLimits.env === 'development') {
           const requestsRemaining = MAX_WINDOW_REQUEST_COUNT - totalWindowRequestsCount;
-          logger.log('info', `Requests made by client: ${totalWindowRequestsCount}\nRequests remaining: ${requestsRemaining}`);
+          const msg = `Requests made by client: ${totalWindowRequestsCount}\nRequests remaining: ${requestsRemaining}`;
+          logger.log('info', msg);
         }
         // if number of requests made is greater than or equal to the desired maximum, return error
         if (totalWindowRequestsCount >= MAX_WINDOW_REQUEST_COUNT) {
           return next({ code: ERROR_CODE });
         }
         // if number of requests made is less than allowed maximum, log new entry
-        let lastRequestLog = data[data.length - 1];
-        let potentialCurrentWindowIntervalStartTimeStamp = currentRequestTime
+        const lastRequestLog = data[data.length - 1];
+        const potentialCurrentWindowIntervalStartTimeStamp = currentRequestTime
           .subtract(WINDOW_LOG_INTERVAL_IN_MINUTES, 'minutes')
           .unix();
         //  if interval has not passed since last request log, increment counter

--- a/middleware/rate-limiter.js
+++ b/middleware/rate-limiter.js
@@ -1,0 +1,89 @@
+
+const moment = require('moment');
+const redis = require('redis');
+
+const redisClient = redis.createClient();
+
+module.exports = (options, rateLimitType) => {
+  const logger = options.logger || { log: (func, msg) => console[func](msg) };
+  const rateLimits = options.rateLimits[rateLimitType];
+  const timestampName = `${rateLimitType}TimeStamp`;
+  const countName = `${rateLimitType}Count`;
+
+  const WINDOW_SIZE_IN_MINUTES = rateLimits.windowSizeInMinutes;
+  const MAX_WINDOW_REQUEST_COUNT = rateLimits.maxWindowRequestCount;
+  const WINDOW_LOG_INTERVAL_IN_MINUTES = rateLimits.windowLogIntervalInMinutes;
+  const ERROR_CODE = rateLimits.errCode;
+
+  return (req, res, next) => {
+    try {
+      // check that redis client exists
+      if (!redisClient) {
+        logger.log('error', 'Redis client does not exist!');
+        return next();
+      }
+      // fetch records of current user using IP address, returns null when no record is found
+      return redisClient.get(req.ip, (err, record) => {
+        if (err) {
+          logger.log('error', `Error with requesting redis session for rate limiting: ${err}`);
+          return next();
+        }
+        const currentRequestTime = moment();
+        const windowStartTimestamp = moment().subtract(WINDOW_SIZE_IN_MINUTES, 'minutes').unix();
+        let oldRecord = false;
+        let data;
+        //  if no record is found , create a new record for user and store to redis
+        if (record) {
+          data = JSON.parse(record);
+          oldRecord = data[data.length - 1][timestampName] < windowStartTimestamp;
+        }
+
+        if (!record || oldRecord) {
+          let newRecord = [];
+          let requestLog = {
+            [timestampName]: currentRequestTime.unix(),
+            [countName]: 1
+          };
+          newRecord.push(requestLog);
+          redisClient.set(req.ip, JSON.stringify(newRecord));
+          return next();
+        }
+        // if record is found, parse it's value and calculate number of requests users has made within the last window
+        let requestsWithinWindow = data.filter(entry => entry[timestampName] > windowStartTimestamp);
+
+        let totalWindowRequestsCount = requestsWithinWindow.reduce((accumulator, entry) => {
+          return accumulator + entry[countName];
+        }, 0);
+
+        if (!options.rateLimits.env || options.rateLimits.env === 'development') {
+          const requestsRemaining = MAX_WINDOW_REQUEST_COUNT - totalWindowRequestsCount;
+          logger.log('info', `Requests made by client: ${totalWindowRequestsCount}\nRequests remaining: ${requestsRemaining}`);
+        }
+        // if number of requests made is greater than or equal to the desired maximum, return error
+        if (totalWindowRequestsCount >= MAX_WINDOW_REQUEST_COUNT) {
+          return next({ code: ERROR_CODE });
+        }
+        // if number of requests made is less than allowed maximum, log new entry
+        let lastRequestLog = data[data.length - 1];
+        let potentialCurrentWindowIntervalStartTimeStamp = currentRequestTime
+          .subtract(WINDOW_LOG_INTERVAL_IN_MINUTES, 'minutes')
+          .unix();
+        //  if interval has not passed since last request log, increment counter
+        if (lastRequestLog[timestampName] > potentialCurrentWindowIntervalStartTimeStamp) {
+          lastRequestLog[countName]++;
+          data[data.length - 1] = lastRequestLog;
+        } else {
+          //  if interval has passed, log new entry for current user and timestamp
+          data.push({
+            [timestampName]: currentRequestTime.unix(),
+            [countName]: 1
+          });
+        }
+        redisClient.set(req.ip, JSON.stringify(data));
+        return next();
+      });
+    } catch (err) {
+      return next(err);
+    }
+  };
+};

--- a/sandbox/server.js
+++ b/sandbox/server.js
@@ -8,5 +8,10 @@ bootstrap({
   routes: [
     require('./apps/sandbox')
   ],
+  rateLimits: {
+    requests: {
+      active: true
+    }
+  },
   getAccessibility: true
 });

--- a/test/integration/bootstrap.spec.js
+++ b/test/integration/bootstrap.spec.js
@@ -147,8 +147,7 @@ describe('bootstrap()', () => {
       });
 
       return bs.should.have.all.keys('server', 'stop', 'start', 'use');
-    }
-    );
+    });
 
     it('can instantiate a custom behaviour for the route', () => {
       bs = bootstrap({

--- a/test/integration/server.spec.js
+++ b/test/integration/server.spec.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const request = require('supertest');
+const _ = require('lodash');
+const redis = require('redis');
 
 const testTag = 'Test-GA-Tag';
 process.env.GA_TAG = testTag;
@@ -699,6 +701,85 @@ describe('hof server', () => {
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
         .expect('<div>test</div>\n');
+    });
+  });
+
+  describe('with rate limits', () => {
+    let redisClient;
+    let reqMiddleware;
+
+    beforeEach(() => {
+      redisClient = redis.createClient();
+    });
+
+    afterEach(() => {
+      redisClient.del(reqMiddleware.ip);
+    });
+
+    it('does not set up rate limits for requests if they are disabled', () => {
+      const bs = bootstrap({
+        fields: 'fields',
+        routes: [{
+          views: `${root}/views`,
+          pages: {
+            '/a-static-page': 'test'
+          }
+        }],
+        rateLimits: {
+          requests: {
+            active: false
+          }
+        }
+      });
+
+      bs.use((req, res) => {
+        reqMiddleware = req;
+        res.json({});
+      });
+
+      return request(bs.server)
+        .get('/a-static-page')
+        .set('Cookie', ['myCookie=1234'])
+        .expect(200)
+        .expect(async () => {
+          await redisClient.get(reqMiddleware.ip, (err, record) => {
+            const recordCount = _.sum(_.map(JSON.parse(record), obj => obj.requestsCount));
+            expect(recordCount).to.eq(0);
+          });
+        });
+    });
+
+    it('sets up rate limits and records request per IP address if they are enabled', () => {
+      const bs = bootstrap({
+        fields: 'fields',
+        routes: [{
+          views: `${root}/views`,
+          pages: {
+            '/a-static-page': 'test'
+          }
+        }],
+        rateLimits: {
+          requests: {
+            active: true
+          }
+        }
+      });
+
+      bs.use((req, res) => {
+        reqMiddleware = req;
+        res.json({});
+      });
+
+      return request(bs.server)
+        .get('/a-static-page')
+        .set('Cookie', ['myCookie=1234'])
+        .expect(200)
+        .expect(async () => {
+          await redisClient.get(reqMiddleware.ip, (err, record) => {
+            const recordCount = _.sum(_.map(JSON.parse(record), obj => obj.requestsCount));
+            expect(recordCount).to.eq(1);
+          });
+        });
     });
   });
 

--- a/test/middleware/rate-limiter.spec.js
+++ b/test/middleware/rate-limiter.spec.js
@@ -1,0 +1,254 @@
+'use strict';
+
+const moment = require('moment');
+
+describe('rate-limiter', () => {
+  let req;
+  let res;
+  let next;
+  let loggerStub;
+  let rateLimiter;
+  let getStub;
+  let setStub;
+  let mockOptions;
+
+  const staticTimeDay = '2022-05-16 12:00';
+
+  beforeEach(() => {
+    req = request();
+    res = response();
+    next = sinon.stub();
+    loggerStub = sinon.stub();
+    getStub = sinon.stub();
+    setStub = sinon.stub();
+
+    req.ip = 'default';
+
+    const defaultMockData = [{
+      requestsTimeStamp: moment(staticTimeDay).subtract(2, 'minute').unix(),
+      requestsCount: 2
+    }];
+
+    const oldMockData = [{
+      requestsTimeStamp: moment(staticTimeDay).subtract(6, 'minutes').unix(),
+      requestsCount: 20
+    }];
+
+    const recentMockData = [{
+      requestsTimeStamp: moment(staticTimeDay).unix(),
+      requestsCount: 20
+    }];
+
+    const submissionMockData = [{
+      submissionsTimeStamp: moment(staticTimeDay).subtract(2, 'minute').unix(),
+      submissionsCount: 100
+    }];
+
+    getStub.withArgs('default').yields(null, JSON.stringify(defaultMockData));
+    getStub.withArgs('old_records').yields(null, JSON.stringify(oldMockData));
+    getStub.withArgs('recent_records').yields(null, JSON.stringify(recentMockData));
+    getStub.withArgs('submission_records').yields(null, JSON.stringify(submissionMockData));
+    getStub.withArgs('no_records').yields(null, null);
+    getStub.withArgs('error').yields('RedisError');
+
+    mockOptions = {
+      logger: { log: loggerStub },
+      rateLimits: {
+        env: 'production',
+        requests: {
+          active: false,
+          windowSizeInMinutes: 5,
+          maxWindowRequestCount: 100,
+          windowLogIntervalInMinutes: 1,
+          errCode: 'DDOS_RATE_LIMIT'
+        },
+        submissions: {
+          active: false,
+          windowSizeInMinutes: 10,
+          maxWindowRequestCount: 1,
+          windowLogIntervalInMinutes: 1,
+          errCode: 'SUBMISSION_RATE_LIMIT'
+        }
+      }
+    };
+
+    rateLimiter = proxyquire('../middleware/rate-limiter', {
+      redis: {
+        createClient: () => {
+          return { get: getStub, set: setStub };
+        }
+      },
+      moment: () => moment(staticTimeDay)
+    });
+  });
+
+  it('logs an error and returns if no redis client is present', () => {
+    rateLimiter = proxyquire('../middleware/rate-limiter', {
+      redis: { createClient: () => null }
+    });
+
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    loggerStub.should.have.been.calledOnce.calledWithExactly('error', 'Redis client does not exist!');
+    getStub.should.not.have.been.called;
+    setStub.should.not.have.been.called;
+    next.should.have.been.calledOnce.calledWithExactly();
+  });
+
+  it('logs an error and returns if their is a Redis get error', () => {
+    req.ip = 'error';
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    const errMsg = 'Error with requesting redis session for rate limiting: RedisError';
+
+    loggerStub.should.have.been.calledOnce.calledWithExactly(req.ip, errMsg);
+    getStub.should.have.been.calledOnce;
+    setStub.should.not.have.been.called;
+    next.should.have.been.calledOnce.calledWithExactly();
+  });
+
+  it('adds a new record if one does not exist', () => {
+    req.ip = 'no_records';
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    const data = JSON.stringify([{
+      requestsTimeStamp: moment(staticTimeDay).unix(),
+      requestsCount: 1
+    }]);
+
+    loggerStub.should.not.have.been.called;
+    getStub.should.have.been.calledOnce;
+    setStub.should.have.been.calledOnce.calledWithExactly(req.ip, data);
+    next.should.have.been.calledOnce.calledWithExactly();
+  });
+
+  it('ignores out of date records and sets a new one', () => {
+    req.ip = 'old_records';
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    const data = JSON.stringify([{
+      requestsTimeStamp: moment(staticTimeDay).unix(),
+      requestsCount: 1
+    }]);
+
+    loggerStub.should.not.have.been.called;
+    getStub.should.have.been.calledOnce;
+    setStub.should.have.been.calledOnce.calledWithExactly(req.ip, data);
+    next.should.have.been.calledOnce.calledWithExactly();
+  });
+
+  it('does not log requests made if running in production mode', () => {
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+    loggerStub.should.not.have.been.called;
+  });
+
+  it('logs requests made if running in development mode', () => {
+    mockOptions.rateLimits.env = 'development';
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    const reqMsg = 'Requests made by client: 2\nRequests remaining: 98';
+    loggerStub.should.have.been.calledOnce.calledWithExactly('info', reqMsg);
+  });
+
+  it('logs requests made if Node environment not set', () => {
+    mockOptions.rateLimits.env = null;
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    const reqMsg = 'Requests made by client: 2\nRequests remaining: 98';
+    loggerStub.should.have.been.calledOnce.calledWithExactly('info', reqMsg);
+  });
+
+  it('calls the callback with an error if request rate limit hit', () => {
+    mockOptions.rateLimits.requests.maxWindowRequestCount = 1;
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    loggerStub.should.not.have.been.called;
+    getStub.should.have.been.calledOnce;
+    setStub.should.not.have.been.called;
+    next.should.have.been.calledOnce.calledWithExactly({ code: 'DDOS_RATE_LIMIT' });
+  });
+
+  it('calls the callback with an error if any other submission type rate limit hit', () => {
+    req.ip = 'submission_records';
+    mockOptions.rateLimits.submissions.maxWindowRequestCount = 99;
+    rateLimiter(mockOptions, 'submissions')(req, res, next);
+
+    loggerStub.should.not.have.been.called;
+    getStub.should.have.been.calledOnce;
+    setStub.should.not.have.been.called;
+    next.should.have.been.calledOnce.calledWithExactly({ code: 'SUBMISSION_RATE_LIMIT' });
+  });
+
+  it('splits out requests made within rate limit window by intervals', () => {
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    const data = JSON.stringify([{
+      requestsTimeStamp: moment(staticTimeDay).subtract(2, 'minutes').unix(),
+      requestsCount: 2
+    }, {
+      requestsTimeStamp: moment(staticTimeDay).subtract(1, 'minute').unix(),
+      requestsCount: 1
+    }]);
+
+    loggerStub.should.not.have.been.called;
+    getStub.should.have.been.calledOnce;
+    setStub.should.have.been.calledOnce.calledWithExactly('default', data);
+    next.should.have.been.calledOnce.calledWithExactly();
+  });
+
+  it('tallies up recent requests if within the same interval window', () => {
+    req.ip = 'recent_records';
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    const data = JSON.stringify([{
+      requestsTimeStamp: moment(staticTimeDay).unix(),
+      requestsCount: 21
+    }]);
+
+    loggerStub.should.not.have.been.called;
+    getStub.should.have.been.calledOnce;
+    setStub.should.have.been.calledOnce.calledWithExactly('recent_records', data);
+    next.should.have.been.calledOnce.calledWithExactly();
+  });
+
+  it('can successfully add and handle other rate limits', () => {
+    req.ip = 'submission_records';
+    mockOptions.rateLimits.submissions.maxWindowRequestCount = 101;
+    rateLimiter(mockOptions, 'submissions')(req, res, next);
+
+    const data = JSON.stringify([{
+      submissionsTimeStamp: moment(staticTimeDay).subtract(2, 'minute').unix(),
+      submissionsCount: 100
+    }, {
+      submissionsTimeStamp: moment(staticTimeDay).subtract(1, 'minute').unix(),
+      submissionsCount: 1
+    }]);
+
+    loggerStub.should.not.have.been.called;
+    getStub.should.have.been.calledOnce;
+    setStub.should.have.been.calledOnce.calledWithExactly('submission_records', data);
+    next.should.have.been.calledOnce.calledWithExactly();
+  });
+
+  it('calls the callback with an error in the event of a fail', () => {
+    rateLimiter = proxyquire('../middleware/rate-limiter', {
+      redis: {
+        createClient: () => {
+          return { get: () => {
+            throw new Error('FAIL');
+          }};
+        }
+      }
+    });
+
+    rateLimiter(mockOptions, 'requests')(req, res, next);
+
+    loggerStub.should.not.have.been.called;
+    setStub.should.not.have.been.called;
+    next.should.have.been.calledOnce;
+
+    const errArg = next.firstCall.args[0];
+    expect(errArg).to.be.instanceof(Error);
+    expect(errArg.message).to.equal('FAIL');
+  });
+});


### PR DESCRIPTION
Add rate limits that check a users session against redis to rate limit how many http requests they make to the form. This is to stop malicious spamming of a service, more specifically submissions being sent.