### PR TITLE
HOFF-25 - Added field type check to sanitise middleware

### DIFF
--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -31,7 +31,8 @@ const defaults = {
   session: {
     ttl: process.env.SESSION_TTL || 1800,
     secret: process.env.SESSION_SECRET || 'changethis',
-    name: process.env.SESSION_NAME || 'hod.sid'
+    name: process.env.SESSION_NAME || 'hod.sid',
+    sanitiseInputs: false
   },
   apis: {
     pdfConverter: process.env.PDF_CONVERTER_URL

--- a/config/sanitisation-rules.js
+++ b/config/sanitisation-rules.js
@@ -1,0 +1,29 @@
+'use strict';
+/* eslint no-process-env: "off" */
+
+const sanitisationBlacklistArray = {
+  // Input will be sanitised using the below rules
+  // The key is what we're sanitising out
+  // The regex is the rule we used to find them (note some dictate repeating characters)
+  // And the replace is what we're replacing that pattern with. Usually nothing sometimes a
+  // single character or sometimes a single character followed by a "-"
+  '/*': { regex: '\/\\*', replace: '' },
+  '*/': { regex: '\\*\\/', replace: '' },
+  '|': { regex: '\\|', replace: '' },
+  '&&': { regex: '&&+', replace: '&' },
+  '@@': { regex: '@@+', replace: '@' },
+  '/..;/': { regex: '/\\.\\.;/', replace: '' }, // Purposely input before ".." as they conflict
+  '..': { regex: '\\.\\.+', replace: '.' },
+  '/etc/passwd': { regex: '\/etc\/passwd', replace: '' },
+  'c:\\': { regex: 'c:\\\\', replace: '' },
+  'cmd.exe': { regex: 'cmd\\.exe', replace: '' },
+  '<': { regex: '<', replace: '<-' },
+  '>': { regex: '>', replace: '>-' },
+  '[': { regex: '\\[+', replace: '[-' },
+  ']': { regex: '\\]+', replace: ']-' },
+  '~': { regex: '~', replace: '~-' },
+  '&#': { regex: '&#', replace: '&#-' },
+  '%U': { regex: '%U', replace: '%U-' }
+};
+
+module.exports = sanitisationBlacklistArray;

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -167,7 +167,7 @@ module.exports = class BaseController extends EventEmitter {
 
   _sanitize(req, res, callback) {
     //Sanitisation could be disabled in the config
-    if(!res.locals.sanitiseInputs) return;
+    if(!this.options.sanitiseInputs) return;
 
     // If we don't have any data, no need to progress
     if(!_.isEmpty(req.form.values)) {

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -166,7 +166,7 @@ module.exports = class BaseController extends EventEmitter {
 
   _sanitize(req, res, callback) {
     // Sanitisation could be disabled in the config
-    if(!this.options.sanitiseInputs) callback();
+    if(!this.options.sanitiseInputs) return callback();
 
     // If we don't have any data, no need to progress
     if(!_.isEmpty(req.form.values)) {

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -166,7 +166,7 @@ module.exports = class BaseController extends EventEmitter {
 
   _sanitize(req, res, callback) {
     //Sanitisation could be disabled in the config
-    if(!this.options.sanitiseInputs) callback();
+    if(!this.options.sanitiseInputs) return callback();
 
     // If we don't have any data, no need to progress
     if(!_.isEmpty(req.form.values)) {

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -9,6 +9,7 @@ const dataFormatter = require('./formatting');
 const dataValidator = require('./validation');
 const ErrorClass = require('./validation-error');
 const sanitisationBlacklistArray = require('../config/sanitisation-rules');
+const { config } = require('bluebird');
 
 module.exports = class BaseController extends EventEmitter {
   constructor(options) {
@@ -165,6 +166,9 @@ module.exports = class BaseController extends EventEmitter {
   }
 
   _sanitize(req, res, callback) {
+    //Sanitisation could be disabled in the config
+    if(!res.locals.sanitiseInputs) return;
+
     // If we don't have any data, no need to progress
     if(!_.isEmpty(req.form.values)) {
       Object.keys(req.form.values).forEach(function (property, propertyIndex) {

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -166,7 +166,7 @@ module.exports = class BaseController extends EventEmitter {
 
   _sanitize(req, res, callback) {
     //Sanitisation could be disabled in the config
-    if(!this.options.sanitiseInputs) return;
+    if(!this.options.sanitiseInputs) callback();
 
     // If we don't have any data, no need to progress
     if(!_.isEmpty(req.form.values)) {

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -165,8 +165,8 @@ module.exports = class BaseController extends EventEmitter {
   }
 
   _sanitize(req, res, callback) {
-    //Sanitisation could be disabled in the config
-    if(!this.options.sanitiseInputs) return callback();
+    // Sanitisation could be disabled in the config
+    if(!this.options.sanitiseInputs) callback();
 
     // If we don't have any data, no need to progress
     if(!_.isEmpty(req.form.values)) {
@@ -183,7 +183,7 @@ module.exports = class BaseController extends EventEmitter {
         }
       });
     }
-    callback();
+    return callback();
   }
 
   _process(req, res, callback) {

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -9,7 +9,6 @@ const dataFormatter = require('./formatting');
 const dataValidator = require('./validation');
 const ErrorClass = require('./validation-error');
 const sanitisationBlacklistArray = require('../config/sanitisation-rules');
-const { config } = require('bluebird');
 
 module.exports = class BaseController extends EventEmitter {
   constructor(options) {

--- a/controller/base-controller.js
+++ b/controller/base-controller.js
@@ -8,6 +8,7 @@ const debug = require('debug')('hmpo:form');
 const dataFormatter = require('./formatting');
 const dataValidator = require('./validation');
 const ErrorClass = require('./validation-error');
+const sanitisationBlacklistArray = require('../config/sanitisation-rules');
 
 module.exports = class BaseController extends EventEmitter {
   constructor(options) {
@@ -69,6 +70,7 @@ module.exports = class BaseController extends EventEmitter {
         this._configure.bind(this),
         this._process.bind(this),
         this._validate.bind(this),
+        this._sanitize.bind(this),
         this._getHistoricalValues.bind(this),
         this.saveValues.bind(this),
         this.successHandler.bind(this),
@@ -160,6 +162,25 @@ module.exports = class BaseController extends EventEmitter {
     const validator = vld || dataValidator(req.form.options.fields);
     const emptyValue = formatter(key, '');
     return validator(key, req.form.values[key], req.form.values, emptyValue);
+  }
+
+  _sanitize(req, res, callback) {
+    // If we don't have any data, no need to progress
+    if(!_.isEmpty(req.form.values)) {
+      Object.keys(req.form.values).forEach(function (property, propertyIndex) {
+        // If it's not a string, don't sanitise it
+        if(_.isString(req.form.values[property])) {
+          // For each property in our form data
+          Object.keys(sanitisationBlacklistArray).forEach(function (blacklisted, blacklistedIndex) {
+            const blacklistedDetail = sanitisationBlacklistArray[blacklisted];
+            const regexQuery = new RegExp(blacklistedDetail.regex, 'gi');
+            // Will perform the required replace based on our passed in regex and the replace string
+            req.form.values[property] = req.form.values[property].replace(regexQuery, blacklistedDetail.replace);
+          });
+        }
+      });
+    }
+    callback();
   }
 
   _process(req, res, callback) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -19,7 +19,8 @@ function getWizardConfig(config) {
   const wizardConfig = {
     name: config.route.name || (config.route.baseUrl || '').replace('/', ''),
     protocol: config.protocol,
-    env: config.env
+    env: config.env,
+    sanitiseInputs: config.sanitiseInputs
   };
 
   if (config.appConfig) {

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -556,11 +556,11 @@ describe('Form Controller', () => {
               value: value
             }
           };
-          let res = {
-            locals: {
-              sanitiseInputs: true
-            }
+          
+          form.options = {
+            sanitiseInputs: true
           };
+
           form._sanitize(req, res, cb);
           req.form.values.value.should.equal(expected);
         });
@@ -571,10 +571,8 @@ describe('Form Controller', () => {
               value: value
             }
           };
-          let res = {
-            locals: {
-              sanitiseInputs: false
-            }
+          form.options = {
+            sanitiseInputs: false
           };
           form._sanitize(req, res, cb);
           req.form.values.value.should.equal(value);
@@ -586,10 +584,8 @@ describe('Form Controller', () => {
         req.form = {
           values: {}
         };
-        let res = {
-          locals: {
-            sanitiseInputs: true
-          }
+        form.options = {
+          sanitiseInputs: true
         };
         form._sanitize(req, res, cb);
         req.form.values.should.be.empty;
@@ -598,10 +594,8 @@ describe('Form Controller', () => {
       // Also check for an empty req.form.values
       it('sanitisation returns correct data when form data is undefined', function () {
         req.form = {};
-        let res = {
-          locals: {
-            sanitiseInputs: true
-          }
+        form.options = {
+          sanitiseInputs: true
         };
         form._sanitize(req, res, cb);
         expect(req.form.values).to.be.undefined;

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -517,6 +517,66 @@ describe('Form Controller', () => {
       form.validate.should.have.been.calledOn(form);
     });
 
+    describe('sanitise inputs', () => {
+      const tests = [
+        { value: 'HELLO\/*TEST*\/WORLD1', expected: 'HELLOTESTWORLD1' },
+        { value: 'HELLO|WORLD2', expected: 'HELLOWORLD2' },
+        { value: 'HELLO&&WORLD3', expected: 'HELLO&WORLD3' },
+        { value: 'HELLO@@WORLD4', expected: 'HELLO@WORLD4' },
+        { value: 'HELLO/..;/WORLD5', expected: 'HELLOWORLD5' },
+        { value: 'HELLO......WORLD6', expected: 'HELLO.WORLD6' },
+        { value: 'HELLO/eTc/paSsWdWORLD7', expected: 'HELLOWORLD7' },
+        { value: 'HELLOC:\\WORLD8', expected: 'HELLOWORLD8' },
+        { value: 'HELLOcMd.ExEWORLD9', expected: 'HELLOWORLD9' },
+        { value: 'HELLO<WORLD10', expected: 'HELLO<-WORLD10' },
+        { value: 'HELLO>WORLD11', expected: 'HELLO>-WORLD11' },
+        { value: 'HELLO[WORLD12', expected: 'HELLO[-WORLD12' },
+        { value: 'HELLO]WORLD13', expected: 'HELLO]-WORLD13' },
+        { value: 'HELLO~WORLD14', expected: 'HELLO~-WORLD14' },
+        { value: 'HELLO&#WORLD15', expected: 'HELLO&#-WORLD15' },
+        { value: 'HELLO%UWORLD16', expected: 'HELLO%U-WORLD16' },
+        {
+          value: '1/*2*/3|4&&5@@6..7/etc/PASSwd8C:\\9Cmd.eXe10/..;/11<12>13[14]15~16&#17%U18',
+          expected: '1234&5@6.7891011<-12>-13[-14]-15~-16&#-17%U-18'
+        },
+        { value: 'Test User', expected: 'Test User'},
+        { value: '123 Test Street', expected: '123 Test Street'},
+        { value: 'London', expected: 'London'},
+        { value: 'United Kingdom', expected: 'United Kingdom'},
+        { value: '2022-01-01', expected: '2022-01-01' },
+        { value: false, expected: false },
+        { value: 12345, expected: 12345 }
+      ];
+
+      tests.forEach(({value, expected}) => {
+        it('sanitisation returns correct data', function () {
+          req.form = {
+            values: {
+              value: value
+            }
+          };
+          form._sanitize(req, res, cb);
+          req.form.values.value.should.equal(expected);
+        });
+      });
+
+      // Also check for an empty req.form.values
+      it('sanitisation returns correct data when form data is empty', function () {
+        req.form = {
+          values: {}
+        };
+        form._sanitize(req, res, cb);
+        req.form.values.should.be.empty;
+      });
+
+      // Also check for an empty req.form.values
+      it('sanitisation returns correct data when form data is undefined', function () {
+        req.form = {};
+        form._sanitize(req, res, cb);
+        expect(req.form.values).to.be.undefined;
+      });
+    });
+
     describe('valid inputs', () => {
       it('calls form.saveValues', () => {
         form.post(req, res, cb);

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -6,7 +6,6 @@ const formatters = require('../../../controller/formatting/formatters');
 const FormError = require('../../../controller/validation-error');
 
 const _ = require('lodash');
-const { escapeSelector } = require('jquery');
 const EventEmitter = require('events').EventEmitter;
 
 describe('Form Controller', () => {
@@ -556,11 +555,9 @@ describe('Form Controller', () => {
               value: value
             }
           };
-          
           form.options = {
             sanitiseInputs: true
           };
-
           form._sanitize(req, res, cb);
           req.form.values.value.should.equal(expected);
         });

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -518,7 +518,7 @@ describe('Form Controller', () => {
       form.validate.should.have.been.calledOn(form);
     });
 
-    describe.only('sanitise inputs', () => {
+    describe('sanitise inputs', () => {
       const tests = [
         { value: 'HELLO\/*TEST*\/WORLD1', expected: 'HELLOTESTWORLD1' },
         { value: 'HELLO|WORLD2', expected: 'HELLOWORLD2' },

--- a/wizard/index.js
+++ b/wizard/index.js
@@ -69,7 +69,8 @@ const Wizard = (steps, fields, setts) => {
     options.confirmStep = settings.confirmStep;
     options.clearSession = options.clearSession || false;
     options.fieldsConfig = _.cloneDeep(fields);
-
+    options.sanitiseInputs = settings.sanitiseInputs;
+    
     options.defaultFormatters = [].concat(settings.formatters);
 
     // default template is the same as the pathname

--- a/wizard/index.js
+++ b/wizard/index.js
@@ -70,7 +70,7 @@ const Wizard = (steps, fields, setts) => {
     options.clearSession = options.clearSession || false;
     options.fieldsConfig = _.cloneDeep(fields);
     options.sanitiseInputs = settings.sanitiseInputs;
-    
+
     options.defaultFormatters = [].concat(settings.formatters);
 
     // default template is the same as the pathname


### PR DESCRIPTION
What?
Added resolutions for non-vulnerable child-of-child dependencies.

Why?
nginx is causing issues when users enter potentially dangerous input and their journey though the services is coming to a stop with no information on the issue. This change is to replace the need for input validation using nginx and give the users more feedback without ending their journey.

How?
We have created a blacklist of input data that we want to strip out of the session

Testing?
This has been tested locally and will be tested in each service individually.

Screenshots (optional)
N/A

Anything Else?
N/A