### PR TITLE
Replaced empty sanitisation rules with hypens and updated tests

### DIFF
--- a/config/sanitisation-rules.js
+++ b/config/sanitisation-rules.js
@@ -7,16 +7,16 @@ const sanitisationBlacklistArray = {
   // The regex is the rule we used to find them (note some dictate repeating characters)
   // And the replace is what we're replacing that pattern with. Usually nothing sometimes a
   // single character or sometimes a single character followed by a "-"
-  '/*': { regex: '\/\\*', replace: '' },
-  '*/': { regex: '\\*\\/', replace: '' },
-  '|': { regex: '\\|', replace: '' },
+  '/*': { regex: '\/\\*', replace: '-' },
+  '*/': { regex: '\\*\\/', replace: '-' },
+  '|': { regex: '\\|', replace: '-' },
   '&&': { regex: '&&+', replace: '&' },
   '@@': { regex: '@@+', replace: '@' },
-  '/..;/': { regex: '/\\.\\.;/', replace: '' }, // Purposely input before ".." as they conflict
+  '/..;/': { regex: '/\\.\\.;/', replace: '-' }, // Purposely input before ".." as they conflict
   '..': { regex: '\\.\\.+', replace: '.' },
-  '/etc/passwd': { regex: '\/etc\/passwd', replace: '' },
-  'c:\\': { regex: 'c:\\\\', replace: '' },
-  'cmd.exe': { regex: 'cmd\\.exe', replace: '' },
+  '/etc/passwd': { regex: '\/etc\/passwd', replace: '-' },
+  'c:\\': { regex: 'c:\\\\', replace: '-' },
+  'cmd.exe': { regex: 'cmd\\.exe', replace: '-' },
   '<': { regex: '<', replace: '<-' },
   '>': { regex: '>', replace: '>-' },
   '[': { regex: '\\[+', replace: '[-' },

--- a/test/controller/spec/base-controller.spec.js
+++ b/test/controller/spec/base-controller.spec.js
@@ -519,15 +519,15 @@ describe('Form Controller', () => {
 
     describe('sanitise inputs', () => {
       const tests = [
-        { value: 'HELLO\/*TEST*\/WORLD1', expected: 'HELLOTESTWORLD1' },
-        { value: 'HELLO|WORLD2', expected: 'HELLOWORLD2' },
+        { value: 'HELLO\/*TEST*\/WORLD1', expected: 'HELLO-TEST-WORLD1' },
+        { value: 'HELLO|WORLD2', expected: 'HELLO-WORLD2' },
         { value: 'HELLO&&WORLD3', expected: 'HELLO&WORLD3' },
         { value: 'HELLO@@WORLD4', expected: 'HELLO@WORLD4' },
-        { value: 'HELLO/..;/WORLD5', expected: 'HELLOWORLD5' },
+        { value: 'HELLO/..;/WORLD5', expected: 'HELLO-WORLD5' },
         { value: 'HELLO......WORLD6', expected: 'HELLO.WORLD6' },
-        { value: 'HELLO/eTc/paSsWdWORLD7', expected: 'HELLOWORLD7' },
-        { value: 'HELLOC:\\WORLD8', expected: 'HELLOWORLD8' },
-        { value: 'HELLOcMd.ExEWORLD9', expected: 'HELLOWORLD9' },
+        { value: 'HELLO/eTc/paSsWdWORLD7', expected: 'HELLO-WORLD7' },
+        { value: 'HELLOC:\\WORLD8', expected: 'HELLO-WORLD8' },
+        { value: 'HELLOcMd.ExEWORLD9', expected: 'HELLO-WORLD9' },
         { value: 'HELLO<WORLD10', expected: 'HELLO<-WORLD10' },
         { value: 'HELLO>WORLD11', expected: 'HELLO>-WORLD11' },
         { value: 'HELLO[WORLD12', expected: 'HELLO[-WORLD12' },
@@ -537,7 +537,7 @@ describe('Form Controller', () => {
         { value: 'HELLO%UWORLD16', expected: 'HELLO%U-WORLD16' },
         {
           value: '1/*2*/3|4&&5@@6..7/etc/PASSwd8C:\\9Cmd.eXe10/..;/11<12>13[14]15~16&#17%U18',
-          expected: '1234&5@6.7891011<-12>-13[-14]-15~-16&#-17%U-18'
+          expected: '1-2-3-4&5@6.7-8-9-10-11<-12>-13[-14]-15~-16&#-17%U-18'
         },
         { value: 'Test User', expected: 'Test User'},
         { value: '123 Test Street', expected: '123 Test Street'},


### PR DESCRIPTION
Fix issue with sanitisation where validation is bypassed when all of the string input is removed by the sanitisation rules.