### PR TITLE
 UKVIC-168: DOB fields not highlighting in firefox when in edit mode.

### DIFF
--- a/frontend/toolkit/assets/javascript/form-focus.js
+++ b/frontend/toolkit/assets/javascript/form-focus.js
@@ -71,9 +71,18 @@ function formFocus() {
   var labels;
   var summaries;
 
-  if (getElementFromSummaryLink && getEditPath === 'edit') {
+  var editMode = getElementFromSummaryLink && getEditPath === 'edit';
+
+  if (getElementFromSummaryLink && document.getElementById(getElementFromSummaryLink) && editMode) {
     document.getElementById(getElementFromSummaryLink).focus();
+  }
+
+  if (getElementFromSummaryLink && document.getElementById(getElementFromSummaryLink + '-group') && editMode) {
     document.getElementById(getElementFromSummaryLink + '-group').scrollIntoView();
+  }
+
+  if (document.getElementById(getElementFromSummaryLink + '-day') && forms.length === 1 && editMode) {
+    document.getElementById(getElementFromSummaryLink + '-day').focus();
   }
 
   if (forms.length > 0) {

--- a/frontend/toolkit/assets/javascript/validation.js
+++ b/frontend/toolkit/assets/javascript/validation.js
@@ -24,7 +24,12 @@ function clicked(e) {
     }
 
     if (inputs) {
-      inputs[0].focus();
+      if (inputs[0].getAttribute('type') === 'hidden') {
+        var getVisibleElements = group.querySelectorAll('input[type=text]');
+        getVisibleElements[0].focus();
+      } else {
+        inputs[0].focus();
+      }
     }
   }
 }


### PR DESCRIPTION
**Changes**	

- Changed form-focus.js to choose the first field when DOB is the only field on the page.
- Fixed dead link in validation message for date of birth group fields in validation.js