### PR TITLE
Pass the host and port to the redis createClient method

### DIFF
--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -20,7 +20,7 @@ const defaults = {
   host: process.env.HOST || '0.0.0.0',
   port: process.env.PORT || '8080',
   env: process.env.NODE_ENV || 'development',
-  gaTagId: process.env.GA_TAG,
+  gaTagId: process.env.GA_TAG || 'Test-GA-Tag',
   ga4TagId: process.env.GA_4_TAG,
   gaCrossDomainTrackingTagId: process.env.GDS_CROSS_DOMAIN_GA_TAG,
   loglevel: process.env.LOG_LEVEL || 'info',

--- a/middleware/rate-limiter.js
+++ b/middleware/rate-limiter.js
@@ -1,6 +1,7 @@
 
 const moment = require('moment');
 const redis = require('redis');
+const config = require('./../config/hof-defaults');
 
 module.exports = (options, rateLimitType) => {
   const logger = options.logger || { log: (func, msg) => console[func](msg) };
@@ -14,7 +15,7 @@ module.exports = (options, rateLimitType) => {
   const ERROR_CODE = rateLimits.errCode;
 
   return async (req, res, next) => {
-    const redisClient = redis.createClient();
+    const redisClient = redis.createClient(config.redis);
 
     // check that redis client exists
     if (!redisClient) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "19.14.5",
+  "version": "19.14.6",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
What
Pass the host and port to the redis createClient method

Why
An connection error occurs when createClient is called without any configuration in the rate limiting feature

How
Pass the host and port as parameters to the redis createClient method

Test
Local manual testing with rate limiting turned on
