### PR TITLE
Bumped actions-yarn to v3

### DIFF
--- a/.github/workflows/automate-publish.yml
+++ b/.github/workflows/automate-publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
-      - uses: borales/actions-yarn@v2.3.0
+      - uses: borales/actions-yarn@v3.0.0
         with:
           cmd: install --frozen-lockfile
       - run: |

--- a/.github/workflows/automate-tag.yml
+++ b/.github/workflows/automate-tag.yml
@@ -18,7 +18,7 @@ jobs:
         uses: supercharge/redis-github-action@1.2.0
         with:
           redis-version: ${{ matrix.redis-version }}
-      - uses: borales/actions-yarn@v2.3.0
+      - uses: borales/actions-yarn@v3.0.0
         with:
           cmd: install --frozen-lockfile
       - run: npm test


### PR DESCRIPTION
Bumped actions-yarn as python2 is now deprecated and unavailable in the alphine APK public repo