### PR TITLE
Update emailer component to handle signature 4 authentication

### DIFF
--- a/components/emailer/emailer.js
+++ b/components/emailer/emailer.js
@@ -20,7 +20,12 @@ module.exports = class Emailer {
 
     const transport = transports[options.transport](options.transportOptions || {});
 
-    this.emailer = nodemailer.createTransport(transport);
+    if (options.transportOptions !== undefined &&
+      options.transportOptions.host !== undefined && options.transportOptions.host !== null) {
+      this.emailer = nodemailer.createTransport(options.transportOptions);
+    } else {
+      this.emailer = nodemailer.createTransport(transport);
+    }
   }
 
   send(to, subject, body) {


### PR DESCRIPTION
What
Pass updated transport options to Nodemailer create transport required for aws sig4 authentication.

Why
SMTP requires host(with AWS Region), port and authentication that have to be added to transport options in service config

How
Pass transport options instead of transport if host exists in the transportOptions.

Test
Manual testing in local and branch