### PR TITLE
Corrected GA4 domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const getContentSecurityPolicy = (config, res) => {
     fontSrc: ['fonts.gstatic.com '],
     scriptSrc: ['www.google-analytics.com', 'ssl.google-analytics.com'],
     imgSrc: ['www.google-analytics.com', 'ssl.gstatic.com'],
-    connectSrc: ['www.google-analytics.com']
+    connectSrc: ['https://www.google-analytics.com', 'https://region1.google-analytics.com']
   };
 
   if (config.gaTagId) {


### PR DESCRIPTION
What
Live services are showing CSP errors when sending GA tracking hits due to incorrect domains.

How
Corrected the domains in index.js

Tested
Tested locally