### PR TITLE
add gov-uk class to template partials

### DIFF
--- a/frontend/template-mixins/partials/forms/input-text-date.html
+++ b/frontend/template-mixins/partials/forms/input-text-date.html
@@ -14,7 +14,7 @@
               type="{{type}}"
               name="{{id}}"
               id="{{id}}"
-              class="govuk-input{{#className}} {{className}}{{/className}}{{#error}} invalid-input{{/error}}"
+              class="govuk-input{{#className}} {{className}}{{/className}}{{#error}} govuk-input—error{{/error}}"
               aria-required="{{required}}"
               {{#value}} value="{{value}}"{{/value}}
               {{#min}} min="{{min}}"{{/min}}

--- a/frontend/template-mixins/partials/forms/input-text-group.html
+++ b/frontend/template-mixins/partials/forms/input-text-group.html
@@ -19,7 +19,7 @@
             type="{{type}}"
             name="{{id}}"
             id="{{id}}"
-            class="{{^className}}govuk-input{{/className}}{{#className}}{{className}}{{/className}}{{#error}} invalid-input{{/error}}"
+            class="{{^className}}govuk-input{{/className}}{{#className}}{{className}}{{/className}}{{#error}} govuk-input—error{{/error}}"
             aria-required="{{required}}"
             {{#value}} value="{{value}}"{{/value}}
             {{#min}} min="{{min}}"{{/min}}

--- a/frontend/template-mixins/partials/forms/select.html
+++ b/frontend/template-mixins/partials/forms/select.html
@@ -9,7 +9,7 @@
         {{/error}}
     </label>
     {{#isPageHeading}}</h1>{{/isPageHeading}}
-    <select id="{{id}}" class="govuk-select{{#className}} {{className}}{{/className}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
+    <select id="{{id}}" class="govuk-select{{#className}} {{className}}{{/className}}{{#error}} govuk-select—error{{/error}}" name="{{id}}" aria-required="{{required}}">
     {{#options}}
         <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>
     {{/options}}

--- a/frontend/template-mixins/partials/forms/textarea-group.html
+++ b/frontend/template-mixins/partials/forms/textarea-group.html
@@ -16,7 +16,7 @@
     <textarea
         name="{{id}}"
         id="{{id}}"
-        class="govuk-textarea{{#className}} {{className}}{{/className}} {{#maxlength}}maxlength{{/maxlength}}{{#error}} invalid-input{{/error}}"
+        class="govuk-textarea{{#className}} {{className}}{{/className}} {{#maxlength}}maxlength{{/maxlength}}{{#error}} govuk-input—error{{/error}}"
         aria-required="{{required}}"
         {{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}
         {{#attributes}}

--- a/frontend/themes/gov-uk/styles/modules/_validation.scss
+++ b/frontend/themes/gov-uk/styles/modules/_validation.scss
@@ -25,7 +25,7 @@
 .govuk-form-group--error {
     box-sizing: border-box;
     padding-left: $gutter-half - $validation-bdr-size;
-    border-left: $validation-bdr-size-lg solid $error-colour;
+    //border-left: $validation-bdr-size-lg solid $error-colour;
 
     &:focus {
         outline: $focus-outline;
@@ -42,7 +42,7 @@
         margin-bottom: 0.5em;
     }
     @include bold-19;
-    color: $error-colour;
+    //color: $error-colour;
 }
 
 .invalid-input,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.0.0-beta.18",
+  "version": "20.0.0-beta.19",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
What
- Added gov-uk class to template partials
- commented out colour property on validation scss file

Reason
- class name invalid input was overriding gov uk design system with an older version
- colour property has been commented out in validation scss file because the error colour used is from another package and is overriding gov uk design system 