### PR TITLE
add config for formatting prefix and suffix input field

### DIFF
--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -215,6 +215,7 @@ module.exports = function (options) {
         child: field.child,
         isPageHeading: field.isPageHeading,
         attributes: field.attributes,
+        isPrefixOrSuffix: _.map(field.attributes, item => {if (item.prefix || item.suffix !== undefined) return true;}),
         renderChild: renderChild.bind(this)
       });
     }

--- a/frontend/template-mixins/partials/forms/input-text-group.html
+++ b/frontend/template-mixins/partials/forms/input-text-group.html
@@ -10,6 +10,7 @@
       </p>
     {{/error}}
     {{#renderChild}}{{/renderChild}}
+    {{#isPrefixOrSuffix}}<div class="govuk-input__wrapper">{{/isPrefixOrSuffix}}
         {{#attributes}}
             {{#prefix}}
                 <div class="govuk-input__prefix" aria-hidden="true">{{prefix}}</div>
@@ -35,7 +36,8 @@
         >
         {{#attributes}}
             {{#suffix}}
-                <div class="govuk-input__prefix" aria-hidden="true">{{suffix}}</div>
+                <div class="govuk-input__suffix" aria-hidden="true">{{suffix}}</div>
             {{/suffix}}
         {{/attributes}}
+    {{#isPrefixOrSuffix}}</div>{{/isPrefixOrSuffix}}
 </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.0.0-beta.26",
+  "version": "20.0.0-beta.27",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
What
- Added prefix or suffix key to template-mixins.js to check if the field has a prefix or suffix
- Created div based on that in input-text-group.html
Why
-  To follow recommended layout for prefixes/suffixes input fields from gov uk design system
Test
- Tested locally 