### PR TITLE
fix change cookie settings link

### DIFF
--- a/frontend/template-partials/views/partials/cookie-banner.html
+++ b/frontend/template-partials/views/partials/cookie-banner.html
@@ -20,7 +20,7 @@
 	</div>
 	<div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="0" hidden=""  id="cookie-banner-submitted" >
 		<p class="gem-c-cookie-banner__confirmation-message" role="alert">
-      Your cookie preferences have been saved. You can <a class="govuk-link" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation" href="/student-help/cookies">change your cookie settings</a> at any time.
+      Your cookie preferences have been saved. You can <a class="govuk-link" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation" href="/cookies">change your cookie settings</a> at any time.
     </p>
 		<div class="govuk-button-group">
 			<button   class="gem-c-cookie-banner__hide-button govuk-button"  id="hide-cookie-banner">Hide this message</button>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.0.0-beta.27",
+  "version": "20.0.0-beta.28",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
## What
- revert 'change your cookie settings' link to '/cookies'
## Why
- link was set as '/student-help/cookies' which was a non-existent page
## Testing
- tested locally