### PR TITLE
fix error link for input date

### DIFF
--- a/controller/controller.js
+++ b/controller/controller.js
@@ -177,7 +177,7 @@ module.exports = class Controller extends BaseController {
           // eslint-disable-next-line brace-style
           }
           // get first field for date input control
-          else if (field && field.controlType === 'date-input') {
+          else if (field && field.mixin === 'input-date') {
             req.form.errors[key].errorLinkId = key + '-day';
           } else {
             req.form.errors[key].errorLinkId = key;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.0.0-beta.28",
+  "version": "20.0.0-beta.29",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
What
Fixed issue with user unable to click validation summary which should link to input date field. This fix now follows more closely to the latest design system service update.

How
Checks to see if field.mixin is equal to input-date, if true it sets the field-day to the error link id which is where the user is taken when the user clicks on the validation summary. Replaced field.controlType with field.mixin as that property does not seem to exist as part of the form options fields.

Tested
Locally on example app, fields that are input date need to have mixin: input-date in fields.js