### PR TITLE
Error link for radio and checkbox + input-date mixin in sandbox

### DIFF
--- a/controller/controller.js
+++ b/controller/controller.js
@@ -171,9 +171,14 @@ module.exports = class Controller extends BaseController {
       Object.keys(req.form.errors).forEach(key => {
         if (req.form && req.form.options && req.form.options.fields) {
           const field = req.form.options.fields[key];
-          // get first option for radios
-          if (field.mixin === 'radio-group') {
-            req.form.errors[key].errorLinkId = key + '-' + field.options[0];
+          // get first option for radios and checkbox
+          if (field.mixin === 'radio-group' || field.mixin === 'checkbox-group') {
+            // get first option for radios and checkbox where there is a toggle
+            if(typeof field.options[0] === 'object') {
+              req.form.errors[key].errorLinkId = key + '-' + field.options[0].value;
+            } else {
+              req.form.errors[key].errorLinkId = key + '-' + field.options[0];
+            }
           // eslint-disable-next-line brace-style
           }
           // get first field for date input control

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.0.0-beta.29",
+  "version": "20.0.0-beta.30",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",

--- a/sandbox/apps/sandbox/fields.js
+++ b/sandbox/apps/sandbox/fields.js
@@ -21,6 +21,7 @@ module.exports = {
     isPageHeading: 'true'
   },
   'dateOfBirth': dateComponent('dateOfBirth', {
+    mixin: 'input-date',
     isPageHeading: 'true',
     validate: [
       'required',


### PR DESCRIPTION
## What?
- add error link for checkbox as well as for radio and checkboxes where there is a toggle
- add input-date mixin to sandbox
## Why?
- Error link: There was no error link set for checkboxes. Also, where a radio or checkbox had a toggle, the error link did not highlight the first option as it should.
- Input-date mixin: to showcase the error link functionality for dates in the sandbox
## How?
-  Error link: added if block where the first option of a radio/checkbox option was an object due to having toggle.
- Input-date mixin: added mixin to fields.js
## Testing?
Tested locally
