### PR TITLE
remove govuk-radios__hint class from checkbox group

### DIFF
--- a/frontend/template-mixins/partials/forms/checkbox-group.html
+++ b/frontend/template-mixins/partials/forms/checkbox-group.html
@@ -37,7 +37,7 @@
             >
             <label class="govuk-label govuk-checkboxes__label" for="{{key}}-{{value}}">
                 {{{label}}}
-                {{#optionHint}}<div id="{{key}}-{{value}}-item-hint" class="govuk-hint govuk-radios__hint">{{optionHint}}</div>{{/optionHint}}
+                {{#optionHint}}<div id="{{key}}-{{value}}-item-hint" class="govuk-hint">{{optionHint}}</div>{{/optionHint}}
             </label>
         </div>
         {{#renderChild}}{{/renderChild}}


### PR DESCRIPTION
What?
* Removed class 'govuk-radios__hint' from checkbox group 

Why?
* Class 'govuk-radios__hint' was adding unnecessary padding/margin to option hints for checkboxes and is not in design system service. 
* Design system service shows that it should only contain class 'govuk-hint'