### PR TITLE
 UKVIC-174: Fix for broken URL link in title for UKVIC and GRO services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1722,3 +1722,9 @@ Additional vendor JavaScript files are included. These are:
 - safari-cachebuster.js
 
 Copy `assets/javascript/vendor` into your javascript directory (ie `hmpo/vendor`) and compile them with your JavaScript.
+
+## Journey Header Navigation.html page
+
+- Navigation.html contains a journeyHeaderURL, which is set in the controller. 
+- getJourneyHeaderURL within the controller translates an empty baseURL to '/'.
+- The above helps fix broken journey header URLs in the GRO and UKVIC services which both have a baseURL's set to '/'.

--- a/controller/controller.js
+++ b/controller/controller.js
@@ -113,6 +113,7 @@ module.exports = class Controller extends BaseController {
       baseUrl: req.baseUrl,
       skipToMain: this.getFirstFormItem(req.form.options.fields),
       title: this.getTitle(route, lookup, req.form.options.fields, res.locals),
+      journeyHeaderURL: this.getJourneyHeaderURL(req.baseUrl),
       header: this.getHeader(route, lookup, res.locals),
       captionHeading: this.getCaptionHeading(route, lookup, res.locals),
       warning: this.getWarning(route, lookup, res.locals),
@@ -122,6 +123,10 @@ module.exports = class Controller extends BaseController {
       nextPage: this.getNextStep(req, res),
       errorLength: this.getErrorLength(req, res)
     }, stepLocals);
+  }
+
+  getJourneyHeaderURL(url) {
+    return url === '' ? '/' : url;
   }
 
   getFirstFormItem(fields) {

--- a/frontend/template-partials/views/partials/navigation.html
+++ b/frontend/template-partials/views/partials/navigation.html
@@ -1,8 +1,8 @@
 <div class="govuk-header__content">
   {{#startPageRedirectUrl}}
-    <a href="{{startPageRedirectUrl}}" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">{{$journeyHeader}}{{/journeyHeader}}</a>  
+    <a href="{{startPageRedirectUrl}}" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">{{$journeyHeader}}{{/journeyHeader}}</a>
   {{/startPageRedirectUrl}}
   {{^startPageRedirectUrl}}
-    <a href="{{baseUrl}}" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">{{$journeyHeader}}{{/journeyHeader}}</a> 
+    <a href="{{journeyHeaderURL}}" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">{{$journeyHeader}}{{/journeyHeader}}</a>
   {{/startPageRedirectUrl}}
 </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.0.0-beta.32",
+  "version": "20.0.0-beta.38",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
**Changes**
    
- New titleUrl created in controller.js using the baseUrl.
- navigation.html uses the new titleUrl in the template.
- Readme documentation updated to include journeyHeaderURL.
