### PR TITLE
remove tab border from cookie banner

### DIFF
--- a/frontend/template-partials/views/partials/cookie-banner.html
+++ b/frontend/template-partials/views/partials/cookie-banner.html
@@ -18,7 +18,7 @@
 				<a class="govuk-link" href="/cookies">View cookies</a>
 		</div>
 	</div>
-	<div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="0" hidden=""  id="cookie-banner-submitted" >
+	<div class="gem-c-cookie-banner__confirmation govuk-width-container" hidden=""  id="cookie-banner-submitted" >
 		<p class="gem-c-cookie-banner__confirmation-message" role="alert">
       Your cookie preferences have been saved. You can <a class="govuk-link" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation" href="/cookies">change your cookie settings</a> at any time.
     </p>


### PR DESCRIPTION
## What 
- Remove tab border from cookie banner
## Why 
- The border around the cookie banner created when clicking tab was oddly shaped. Following the govuk design system guidelines, there is no tab index set for the cookie banner div so this border should not be there.
## How
- Removed the tab index in cookie-banner.html
## Testing
- Tested locally