### PR TITLE
Update textarea config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1530,6 +1530,7 @@ To render a specific fields in your templates use the mixin name (matching those
 - `required`: Value applied to `aria-required` HTML attribute.
 - `hint`: This adds context to the label, which it is a part of, for input text, radio groups and textarea. It is used within the input by aria-describedby for screen readers.
 - `maxlength`: Applicable to text-based fields and mapped to the `maxlength` HTML attribute.
+- `maxword`: Applicable to textarea fields.
 - `options`: Applicable to HTML `select` and `radio` controls and used to generate the items of either HTML element.
 - `selected`: Applicable to `select`, `checkbox`, and `radio` controls. Will render the selected HTML option/element selected or checked.
 - `legend`: Applicable to `radio` button controls, which are wrapped in a HTML `fieldset` with a `legend` element.

--- a/controller/validation/validators.js
+++ b/controller/validation/validators.js
@@ -62,6 +62,10 @@ module.exports = Validators = {
     return Validators.string(value) && (value === '' || value.length <= length);
   },
 
+  maxword(value, length) {
+    return Validators.string(value) && (value === '' || value.split(/\s+/).length <= length);
+  },
+
   exactlength(value, length) {
     return Validators.string(value) && (value === '' || value.length === length);
   },

--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -42,6 +42,15 @@ module.exports = function (options) {
     return null;
   }
 
+  function maxword(field) {
+    const validation = field.validate || [];
+    const mw = _.findWhere(validation, { type: 'maxword' });
+    if (mw) {
+      return _.isArray(mw.arguments) ? mw.arguments[0] : mw.arguments;
+    }
+    return null;
+  }
+
   function type(field) {
     return field.type || 'text';
   }
@@ -208,6 +217,7 @@ module.exports = function (options) {
         hintId: extension.hintId || (hint ? key + '-hint' : null),
         error: this.errors && this.errors[key],
         maxlength: maxlength(field) || extension.maxlength,
+        maxword: maxword(field) || extension.maxword,
         required: required,
         pattern: extension.pattern,
         date: extension.date,
@@ -216,6 +226,7 @@ module.exports = function (options) {
         isPageHeading: field.isPageHeading,
         attributes: field.attributes,
         isPrefixOrSuffix: _.map(field.attributes, item => {if (item.prefix || item.suffix !== undefined) return true;}),
+        isMaxlengthOrMaxword: maxlength(field) || extension.maxlength || maxword(field) || extension.maxword,
         renderChild: renderChild.bind(this)
       });
     }

--- a/frontend/template-mixins/partials/forms/textarea-group.html
+++ b/frontend/template-mixins/partials/forms/textarea-group.html
@@ -1,32 +1,35 @@
-{{#maxlength}}
-<div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="{{maxlength}}">
-{{/maxlength}}
-<div id="{{id}}-group" class="{{#compound}}form-group-compound {{/compound}}{{#formGroupClassName}}{{formGroupClassName}}{{/formGroupClassName}}{{#error}} govuk-form-group--error{{/error}}">
-    {{#isPageHeading}}<h1 class="govuk-label-wrapper">{{/isPageHeading}}<label for="{{id}}" class="{{labelClassName}}{{#isPageHeading}}govuk-label--l{{/isPageHeading}}">
-        {{{label}}}
-        {{#error}} 
-        <p id="{{id}}-error" class="govuk-error-message">
-            <span id="{{id}}-error" class="govuk-visually-hidden">Error:</span>{{error.message}}
-          </p>
-        {{/error}}
-    </label>
-    {{#isPageHeading}}</h1>{{/isPageHeading}}
-    {{#hint}}<div {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{hint}}</div>{{/hint}}
-    {{#renderChild}}{{/renderChild}}
-    <textarea
-        name="{{id}}"
-        id="{{id}}"
-        class="govuk-textarea{{#className}} {{className}}{{/className}} {{#maxlength}}maxlength{{/maxlength}}{{#error}} govuk-input--error{{/error}}"
-        aria-required="{{required}}"
-        {{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}
-        {{#attributes}}
-            {{attribute}}="{{value}}"
-        {{/attributes}}
-        {{^error}}{{#hintId}}{{#maxlength}} aria-describedby="{{id}}-maxlength-hint {{hintId}}"{{/maxlength}}{{/hintId}}{{/error}}
-        {{^error}}{{#hintId}}{{^maxlength}} aria-describedby="{{hintId}}"{{/maxlength}}{{/hintId}}{{/error}}
-        {{^error}}{{^hintId}}{{#maxlength}} aria-describedby="{{id}}-maxlength-hint"{{/maxlength}}{{/hintId}}{{/error}}
-        {{#error}} aria-invalid="true" aria-describedby="{{id}}-error"{{/error}}
-    >{{value}}</textarea>
-    {{#maxlength}}<div id="{{id}}-maxlength-hint" class="govuk-character-count__message" aria-live="polite">You have {{maxlength}} characters remaining</div>{{/maxlength}}
-</div>
-{{#maxlength}}</div>{{/maxlength}}
+{{#isMaxlengthOrMaxword}}<div class="govuk-character-count" data-module="govuk-character-count"
+    {{#maxlength}}data-maxlength="{{maxlength}}" {{/maxlength}} {{#maxword}}data-maxwords="{{maxword}}" {{/maxword}}>
+    {{/isMaxlengthOrMaxword}}
+    <div id="{{id}}-group" class="govuk-form-group {{#formGroupClassName}}{{formGroupClassName}}{{/formGroupClassName}}{{#error}} govuk-form-group--error{{/error}}">
+        {{#isPageHeading}}<h1 class="govuk-label-wrapper">{{/isPageHeading}}
+            <label for="{{id}}"
+                class="{{labelClassName}}{{#isPageHeading}}govuk-label--l{{/isPageHeading}}">
+                {{{label}}}
+                {{#error}}
+                <p id="{{id}}-error" class="govuk-error-message">
+                    <span id="{{id}}-error" class="govuk-visually-hidden">Error:</span>{{error.message}}
+                </p>
+                {{/error}}
+            </label>
+        {{#isPageHeading}}</h1>{{/isPageHeading}}
+        {{#hint}}<div {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{hint}}</div>{{/hint}}
+        {{#renderChild}}{{/renderChild}}
+        <textarea name="{{id}}" id="{{id}}"
+            class="govuk-textarea {{#isMaxlengthOrMaxword}}govuk-js-character-count{{/isMaxlengthOrMaxword}} {{#className}}{{className}}{{/className}} {{#error}}govuk-input--error{{/error}}"
+            aria-describedby="{{id}}-info" 
+            {{#attributes}} 
+                {{attribute}}="{{value}}" 
+            {{/attributes}}
+            {{^error}}{{#hintId}}{{#maxlength}} aria-describedby="{{id}}-maxlength-hint {{hintId}}"{{/maxlength}}{{/hintId}}{{/error}}
+            {{^error}}{{#hintId}}{{^maxlength}} aria-describedby="{{hintId}}"{{/maxlength}}{{/hintId}}{{/error}}
+            {{^error}}{{^hintId}}{{#maxlength}}aria-describedby="{{id}}-maxlength-hint" {{/maxlength}}{{/hintId}}{{/error}}
+            {{#error}} aria-invalid="true" aria-describedby="{{id}}-error" {{/error}}
+            >{{value}}</textarea>
+        {{#isMaxlengthOrMaxword}}
+        <div id="{{id}}-info" class=" govuk-hint govuk-character-count__message" aria-live="polite">You have {{#maxlength}}{{maxlength}} characters{{/maxlength}}{{#maxword}}{{maxword}}
+            words{{/maxword}} remaining
+        </div>
+        {{/isMaxlengthOrMaxword}}
+    </div>
+{{#isMaxlengthOrMaxword}}</div>{{/isMaxlengthOrMaxword}}

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "reporter": "spec",
     "require": "test/common.js",
     "recursive": "true",
-    "timeout": "6000",
+    "timeout": "7000",
     "exit": "true"
   },
   "resolutions": {

--- a/sandbox/apps/sandbox/fields.js
+++ b/sandbox/apps/sandbox/fields.js
@@ -16,9 +16,6 @@ module.exports = {
   },
   name: {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
-    // need to remove this for the heading to go
-    labelClassName: ['govuk-label--l'],
-    isPageHeading: 'true'
   },
   'dateOfBirth': dateComponent('dateOfBirth', {
     mixin: 'input-date',
@@ -70,8 +67,6 @@ module.exports = {
     ]
   },
   email: {
-    isPageHeading: 'true',
-    labelClassName: ['govuk-label--l'],
     validate: ['required', 'email']
   },
   phone: {
@@ -95,13 +90,27 @@ module.exports = {
     mixin: 'textarea',
     // we want to ignore default formatters as we want
     // to preserve white space
-    isPageHeading: 'true',
     'ignore-defaults': true,
     // apply the other default formatters
     formatter: ['trim', 'hyphens'],
-    labelClassName: ['govuk-label--l'],
+    isPageHeading: 'true',
     // attributes here are passed to the field element
     validate: ['required', { type: 'maxlength', arguments: 10 }],
+    attributes: [{
+      attribute: 'rows',
+      value: 8
+    }]
+  },
+  whatHappened: {
+    mixin: 'textarea',
+    // we want to ignore default formatters as we want
+    // to preserve white space
+    'ignore-defaults': true,
+    // apply the other default formatters
+    formatter: ['trim', 'hyphens'],
+    isPageHeading: 'true',
+    // attributes here are passed to the field element
+    validate: ['required', { type: 'maxword', arguments: 10 }],
     attributes: [{
       attribute: 'rows',
       value: 8

--- a/sandbox/apps/sandbox/index.js
+++ b/sandbox/apps/sandbox/index.js
@@ -66,6 +66,10 @@ module.exports = {
     },
     '/text-input-area': {
       fields: ['complaintDetails'],
+      next: '/word-count'
+    },
+    '/word-count': {
+      fields: ['whatHappened'],
       next: '/select'
     },
     '/select':{ 

--- a/sandbox/apps/sandbox/sections/summary-data-sections.js
+++ b/sandbox/apps/sandbox/sections/summary-data-sections.js
@@ -36,5 +36,8 @@ module.exports = {
   ],
   complaintDetails: [
     'complaintDetails'
+  ],
+  whatHappened: [
+    'whatHappened'
   ]
 };

--- a/sandbox/apps/sandbox/translations/src/en/fields.json
+++ b/sandbox/apps/sandbox/translations/src/en/fields.json
@@ -15,7 +15,7 @@
     }
   },
   "name": {
-    "label": "What is your full name?"
+    "label": "Full name"
   },
   "dateOfBirth": {
     "legend": "What is your date of birth?",
@@ -70,7 +70,7 @@
     } 
   },
   "email" : {
-    "label": "Enter your email address"
+    "label": "Email address"
   },
   "phone": {
     "label": "Phone number",
@@ -82,6 +82,10 @@
   "complaintDetails": {
     "label": "Complaint details",
     "hint": "Briefly summarise your complaint. Include anything that can help our investigation."
+  },
+  "whatHappened": {
+    "label": "What happened",
+    "hint": "Briefly summarise what happened."
   },
   "countrySelect": {
     "label": "Which country are you based in?",

--- a/sandbox/apps/sandbox/translations/src/en/pages.json
+++ b/sandbox/apps/sandbox/translations/src/en/pages.json
@@ -10,6 +10,12 @@
     "header": "What is your address in the UK?",
     "intro": "If you have no fixed address, enter an address where we can contact you."
   },
+  "name": {
+    "header": "What is your full name?"
+  },
+  "email": {
+    "header": "Enter your email address"
+  },
   "phone-number": {
     "header": "Enter your phone number"
   },
@@ -36,6 +42,9 @@
       },
       "complaintDetails": {
         "header": "Complaint details"
+      },
+      "whatHappened": {
+        "header": "What happened"
       }
     }
   },

--- a/sandbox/apps/sandbox/translations/src/en/validation.json
+++ b/sandbox/apps/sandbox/translations/src/en/validation.json
@@ -44,6 +44,10 @@
     "default": "Enter details about why you are making a complaint",
     "maxlength": "Keep to the {{maxlength}} character limit"
   },
+  "whatHappened": {
+    "default": "Enter details about what happened",
+    "maxword": "Keep to the {{maxword}} word limit"
+  },
   "appealStages": {
     "required": "Select an appeal stage from the list"
   }

--- a/sandbox/test/_features/sandbox/complex_form.feature
+++ b/sandbox/test/_features/sandbox/complex_form.feature
@@ -32,6 +32,9 @@ Feature: Complex Form
     Then I should be on the 'text-input-area' page showing 'What are the details of your complaint?'
     Then I fill 'complaintDetails' text area with 'I would like to make a complaint'
     Then I click the 'Continue' button
+    Then I should be on the 'word-count' page showing 'What happened'
+    Then I fill 'whatHappened' text area with 'This is what happened'
+    Then I click the 'Continue' button
     Then I should be on the 'select' page showing 'What is the appeal stage?'
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
     Then I click the 'Continue' button

--- a/sandbox/test/_features/sandbox/validation.feature
+++ b/sandbox/test/_features/sandbox/validation.feature
@@ -116,6 +116,13 @@ Feature: validations
     Then I fill 'complaintDetails' text area with 'I would like to make a complaint'
     Then I click the 'Continue' button
     Then I click the 'Continue' button
+    Then I should see the 'Enter details about what happened' error
+    Then I fill 'whatHappened' text area with 'This is what happened to when I typed in what happened'
+    Then I click the 'Continue' button
+    Then I should see the 'Keep to the 10 word limit' error
+    Then I fill 'whatHappened' text area with 'This is what happened"
+    Then I click the 'Continue' button
+    Then I click the 'Continue' button
     Then I should see the 'Select an appeal stage from the list' error
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
     Then I click the 'Continue' button

--- a/sandbox/test/_unit/example_app/sections/summary-data-sections.spec.js
+++ b/sandbox/test/_unit/example_app/sections/summary-data-sections.spec.js
@@ -76,6 +76,15 @@ describe('Apply Summary Data Sections', () => {
       const result = areOrderedEqual(sectionFields, expectedFields);
       expect(result).to.be.true;
     });
+
+    it('should check expected fields in what happened field', () => {
+      const sectionFields = mappedSections.whatHappened;
+      const expectedFields = [
+        'whatHappened'
+      ];
+      const result = areOrderedEqual(sectionFields, expectedFields);
+      expect(result).to.be.true;
+    });
   });
 
   describe('Sections and Fields', () => {
@@ -118,6 +127,13 @@ describe('Apply Summary Data Sections', () => {
       expect(containsAll(
         Object.keys(fields),
         mappedSections.complaintDetails)
+      ).to.be.true;
+    });
+
+    it('whatHappened', () => {
+      expect(containsAll(
+        Object.keys(fields),
+        mappedSections.whatHappened)
       ).to.be.true;
     });
   });

--- a/test/controller/spec/controller.spec.js
+++ b/test/controller/spec/controller.spec.js
@@ -8,7 +8,7 @@ const ErrorClass = require('../../../controller/validation-error');
 
 const BaseController = require('../../../controller/base-controller');
 
-describe('controller', () => {
+describe.only('controller', () => {
   let Controller;
   let controller;
 
@@ -900,6 +900,12 @@ describe('controller', () => {
         req.translate.withArgs('validation.key.exactlength').returns('This must be {{exactlength}} characters');
         const error = new ErrorClass('key', { type: 'exactlength', arguments: [10] });
         controller.getErrorMessage(error, req, res).should.equal('This must be 10 characters');
+      });
+
+      it('populates maxword messages with the required length', () => {
+        req.translate.withArgs('validation.key.maxword').returns('This must be {{maxword}} words');
+        const error = new ErrorClass('key', { type: 'maxword', arguments: [10] });
+        controller.getErrorMessage(error, req, res).should.equal('This must be 10 words');
       });
 
       it('populates before messages with the required difference', () => {


### PR DESCRIPTION
## What
- Format textarea to follow govuk design more closely and extend it to include word count 
- Add word count validator
- Amend ReadMe to include 'maxword' option
- Amend format of question page heading in sandbox for consistency
## Why
- To follow govuk design guidelines
- To account for services that may use word count instead of character count
## How 
- Amended template-mixins.js to configure 'maxword' option  
- Amended textarea-group.html 
- Added 'maxword' validator to validator.js
## Testing
Tested locally