### PR TITLE
HOFF-45 fix layout footer order

### DIFF
--- a/frontend/template-partials/views/layout.html
+++ b/frontend/template-partials/views/layout.html
@@ -50,8 +50,8 @@
       {{/footerSupportLinks}}
       {{^footerSupportLinks}}
         <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/cookies">{{#t}}base.cookies{{/t}}</a></li>
-        <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/accessibility">{{#t}}base.accessibility{{/t}}</a></li>
         <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/terms-and-conditions">{{#t}}base.terms{{/t}}</a></li>
+        <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/accessibility">{{#t}}base.accessibility{{/t}}</a></li>
       {{/footerSupportLinks}}
     </ul>
   {{/footerSupportLinks}}


### PR DESCRIPTION
## What

fix layout footer order

## Why

* Terms should be before accessibility according to rotm, firearms and others on uat
* The Govuk design broke that order.  This fixes it