### PR TITLE
Fix github actions stop support for node 10 & 12

### DIFF
--- a/.github/workflows/automate-publish.yml
+++ b/.github/workflows/automate-publish.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: 'Get Previous tag'
         id: previoustag

--- a/.github/workflows/automate-tag.yml
+++ b/.github/workflows/automate-tag.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x]
         redis-version: [4, 5, 6]
     steps:
       - uses: actions/checkout@v2.2.0
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2.2.0
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: |
           git config --local user.email "$(git log --format='%ae' HEAD^!)"
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2.2.0
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: |
           git config --local user.email "$(git log --format='%ae' HEAD^!)"
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v2.2.0
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: |
           git config --local user.email "$(git log --format='%ae' HEAD^!)"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "reporter": "spec",
     "require": "test/common.js",
     "recursive": "true",
-    "timeout": "7000",
+    "timeout": "9000",
     "exit": "true"
   },
   "resolutions": {


### PR DESCRIPTION
## What

Fix github actions stop support for node 10 & 12

## Why

* For some unknown reasons, node v12 redis 4 fails unit tests
* node v10, v12 is not supported anymore so no need to run tests for these