### PR TITLE
HOFF-316: Checkbox and Radio Button Fix for when Java Script is disabled

### DIFF
--- a/frontend/template-mixins/partials/mixins/panel.html
+++ b/frontend/template-mixins/partials/mixins/panel.html
@@ -1,4 +1,4 @@
-<div id="{{toggle}}-panel" class="{{#radioOption}}govuk-radios__conditional govuk-radios__conditional--hidden{{/radioOption}}
-  {{^radioOption}}govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden{{/radioOption}}">
+<div id="{{toggle}}-panel" class="{{#radioOption}}govuk-radios__conditional{{/radioOption}}
+  {{^radioOption}}govuk-checkboxes__conditional{{/radioOption}}">
   {{#renderMixin}}{{/renderMixin}}
 </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.1.12",
+  "version": "20.1.13",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",

--- a/test/frontend/mixins.spec.js
+++ b/test/frontend/mixins.spec.js
@@ -1739,7 +1739,7 @@ describe('Template Mixins', () => {
           middleware(req, res, next);
           res.locals['radio-group']().call(res.locals, 'field-name');
           renderChild = render.lastCall.args[0].renderChild();
-          renderChild.call(fields['field-name'].options[0]).should.be.equal('<div id="child-field-name-panel" class="\n  govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden">\n<div>some html</div></div>\n');
+          renderChild.call(fields['field-name'].options[0]).should.be.equal('<div id="child-field-name-panel" class="\n  govuk-checkboxes__conditional">\n<div>some html</div></div>\n');
           sinon.stub(Hogan, 'compile').returns({
             render: render
           });
@@ -1756,7 +1756,7 @@ describe('Template Mixins', () => {
           sinon.stub(res.locals, 'input-text').returns(function (key) {
             return Hogan.compile('<div>{{key}}</div>').render({ key: key });
           });
-          let output = '<div id="child-field-name-panel" class="\n  govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden">\n';
+          let output = '<div id="child-field-name-panel" class="\n  govuk-checkboxes__conditional">\n';
           output += '<div>child-field-name</div>';
           output += '</div>\n';
           renderChild.call(_.extend({}, fields['field-name'].options[0], res.locals)).should.be.equal(output);
@@ -1830,7 +1830,7 @@ describe('Template Mixins', () => {
           sinon.stub(res.locals, 'input-text').returns(function (key) {
             return Hogan.compile('<div>{{key}}</div>').render({ key: key });
           });
-          let output = '<div id="child-field-name-panel" class="\n  govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden">\n';
+          let output = '<div id="child-field-name-panel" class="\n  govuk-checkboxes__conditional">\n';
           output += '<div>child-field-name</div>';
           output += '</div>\n';
           renderChild.call(_.extend({}, fields['field-name'], res.locals)).should.be.equal(output);


### PR DESCRIPTION
**Changes**

- panel.html changed to allow for radio buttons and checkboxes to function correctly with dependencies when javascript is disabled in the browser.
- HOF version changed to 20.1.13