### PR TITLE
HOF-318: Dependency validation fix for checkbox-groups with multiple dependencies per option

### DIFF
--- a/controller/validation/index.js
+++ b/controller/validation/index.js
@@ -63,7 +63,8 @@ function validate(fields) {
     debug(`Validating field: "${key}" with value: "${value}"`);
 
     function shouldValidate() {
-      let dependent = fields[key].dependent;
+      // validationLink used to validates multiple dependent fields in checkbox-group
+      let dependent = fields[key].dependent || fields[key].validationLink;
 
       if (typeof dependent === 'string') {
         dependent = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.1.15",
+  "version": "20.1.16",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
**Changes**

- validationLink created to make a child field link back to it parent option in checkbox-groups. This is to remedy incorrect validation errors being generated for mulitple child dependency fields when the parent option was not selected.
- HOF updated to 20.1.16