### PR TITLE
Extend SASS config options in hof-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ It is recommended to alias `hof-build` to an npm script in your package.json.
 - `images` - copies images from ./assets/images directory to ./public/images
 - `translate` - compiles translation files
 
+Note: For SASS compilation it's possible to additionally configure the following options via the hof.settings file (see the configuration section below)
+- `outputStyle` - Controls whether the CSS output is compressed or not, expanded (default) = non compressed and compressed = compressed CSS output.
+- `quietDeps` - This controls whether you get deprecation warning shown in the console output, if set to false (default) SASS deprecation warnings will be shown in the console, if set to true then deprecation warnings will not be shown in the console output.
+
 ## Watch
 
 You can additionally run a `watch` task to start a server instance, which will automatically restart based on changes to files. This will also re-perform the tasks above when relevant files change.

--- a/build/tasks/sass/index.js
+++ b/build/tasks/sass/index.js
@@ -26,7 +26,9 @@ module.exports = config => {
       sass.render({
         file: config.sass.src,
         importer: importer({ aliases }),
-        aliases
+        aliases,
+        outputStyle: config.sass.outputStyle,
+        quietDeps: config.sass.quietDeps
       }, (err, result) => err ? reject(err) : resolve(result.css));
     }))
     .then(css => new Promise((resolve, reject) => {

--- a/config/builder-defaults.js
+++ b/config/builder-defaults.js
@@ -12,7 +12,9 @@ module.exports = {
     src: 'assets/scss/app.scss',
     out: 'public/css/app.css',
     match: 'assets/scss/**/*.scss',
-    restart: false
+    restart: false,
+    quietDeps: false,
+    outputStyle: 'expanded'
   },
   translate: {
     src: 'apps/**/translations/src',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.1.17",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",
@@ -84,7 +84,7 @@
     "reqres": "^3.0.1",
     "request": "^2.79.0",
     "rimraf": "^3.0.2",
-    "sass": "^1.35.2",
+    "sass": "^1.56.2",
     "serve-static": "^1.14.1",
     "uglify-js": "^3.14.3",
     "underscore": "^1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8687,10 +8687,10 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sass@^1.35.2:
-  version "1.52.2"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.2.tgz#cd1f03e0e7be5bb2cebcf1c34d735f087d790936"
-  integrity sha512-mfHB2VSeFS7sZlPv9YohB9GB7yWIgQNTGniQwfQ04EoQN0wsQEv7SwpCwy/x48Af+Z3vDeFXz+iuXM3HK/phZQ==
+sass@^1.56.2:
+  version "1.56.2"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.56.2.tgz#9433b345ab3872996c82a53a58c014fd244fd095"
+  integrity sha512-ciEJhnyCRwzlBCB+h5cCPM6ie/6f8HrhZMQOf5vlU60Y1bI1rx5Zb0vlDZvaycHsg/MqFfF1Eq2eokAa32iw8w==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"


### PR DESCRIPTION
The current implementation of hof-build doesn't allow for CSS output to be compressed or warnings to be suppressed (they cause a lot of noise in the console output). This PR adds optional configuration to apply these 2 options via hof.settings, anyone not choosing to configure either of them will see the default behaviour ie. not compressed CSS output and deprecation warnings showing in the console output when compiling SASS.