### PR TITLE
ASCS-139 Add id to date input div to fix missing link from error alert

### DIFF
--- a/components/date/templates/date.html
+++ b/components/date/templates/date.html
@@ -13,7 +13,7 @@
         <span class="govuk-visually-hidden">Error:</span> {{error.message}}
       </p>
     {{/error}}
-  <div class="govuk-date-input">
+  <div id="{{key}}" class="govuk-date-input">
     {{#input-date}}{{key}}{{/input-date}}
   </div>
 </fieldset>


### PR DESCRIPTION
## What

Relating to [ASCS-139](https://collaboration.homeoffice.gov.uk/jira/browse/ASCS-139)
Adding an id of `{{key}}` to the container `div` for the date element.

## Why

ASCS-139 reports an issue with samepage links from individual error messages in the 'There's a problem' error alert box to the element that errored when that error is on an incorrectly filled date component.

In hof v20.0.1 the `components/date/templates/date.html` had the following line removed: `<input type="hidden" name="{{key}}" />` Without it there is no id or name with {{key}} in the date component template for the error link to move to.

## Testing

Issue found on ASC running hof@20.2.13 and issue fixed with this update made locally. This issue is not found on UAT environments of forms running hof < 20.0.1 e.g. UKVI