### PR TITLE
SASP-59: Fix broken aria reference accessibility error

### DIFF
--- a/frontend/template-mixins/partials/forms/textarea-group.html
+++ b/frontend/template-mixins/partials/forms/textarea-group.html
@@ -17,7 +17,12 @@
         {{#renderChild}}{{/renderChild}}
         <textarea name="{{id}}" id="{{id}}"
             class="govuk-textarea {{#isMaxlengthOrMaxword}}govuk-js-character-count{{/isMaxlengthOrMaxword}} {{#className}}{{className}}{{/className}} {{#error}}govuk-input--error{{/error}}"
-            aria-describedby="{{id}}-info" 
+            {{#isMaxlengthOrMaxword}}
+            aria-describedby="{{id}}-info"
+            {{/isMaxlengthOrMaxword}}
+            {{^isMaxlengthOrMaxword}}
+            aria-describedby="{{id}}"
+            {{/isMaxlengthOrMaxword}}
             {{#attributes}} 
                 {{attribute}}="{{value}}" 
             {{/attributes}}


### PR DESCRIPTION
## What 
- Fixed broken aria reference  error raised in [SASP-59](https://collaboration.homeoffice.gov.uk/jira/browse/SASP-59) 

## Why
 -   In the textarea view, `aria-describedby` value  had an '-info' suffix that referred to the character count div, but when textareas did not have a maxlength/maxword attribute specified, a broken aria reference error occurred.
 - 
## How
- Amended textarea view to include a switch to prevent broken aria reference error when maxlength/maxword attribute is not being used

## Testing
- Tests passing locally