### PR TITLE
SASP-75: Fix accessibility issue 

### DIFF
--- a/frontend/template-mixins/partials/forms/textarea-group.html
+++ b/frontend/template-mixins/partials/forms/textarea-group.html
@@ -20,9 +20,6 @@
             {{#isMaxlengthOrMaxword}}
             aria-describedby="{{id}}-info"
             {{/isMaxlengthOrMaxword}}
-            {{^isMaxlengthOrMaxword}}
-            aria-describedby="{{id}}"
-            {{/isMaxlengthOrMaxword}}
             {{#attributes}} 
                 {{attribute}}="{{value}}" 
             {{/attributes}}


### PR DESCRIPTION
## What
- Fixed accessibility issue raised in [SASP-75](https://collaboration.homeoffice.gov.uk/jira/browse/SASP-75) where hint text not announced by screen reader when tabbing into field

## Why
- This might result in a screen reader user entering inaccurate or incomplete information into the application form. They could still get the screen reader to read the text by using the up and down arrow keys but if they don’t know it’s there then they would not necessarily do that.

## How
- Removed unnecessary `aria-describedby` attribute that was stopping existing hint `aria-describedy` attribute from being read.

## Testing
- Test passing locally