### PR TITLE
Added text area hint to the accessibility description for text area

### DIFF
--- a/frontend/template-mixins/partials/forms/textarea-group.html
+++ b/frontend/template-mixins/partials/forms/textarea-group.html
@@ -18,10 +18,10 @@
         <textarea name="{{id}}" id="{{id}}"
             class="govuk-textarea {{#isMaxlengthOrMaxword}}govuk-js-character-count{{/isMaxlengthOrMaxword}} {{#className}}{{className}}{{/className}} {{#error}}govuk-input--error{{/error}}"
             {{#isMaxlengthOrMaxword}}
-            aria-describedby="{{id}}-info"
+            aria-describedby="{{id}}-hint {{id}}-info"
             {{/isMaxlengthOrMaxword}}
-            {{#attributes}} 
-                {{attribute}}="{{value}}" 
+            {{#attributes}}
+                {{attribute}}="{{value}}"
             {{/attributes}}
             {{^error}}{{#hintId}}{{#maxlength}} aria-describedby="{{id}}-maxlength-hint {{hintId}}"{{/maxlength}}{{/hintId}}{{/error}}
             {{^error}}{{#hintId}}{{^maxlength}} aria-describedby="{{hintId}}"{{/maxlength}}{{/hintId}}{{/error}}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.3.2",
+  "version": "20.3.3",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
**What**
Added the missing text area hint to the accessibility description for text area

**Why**
When tabbing or shift+tabbing into a text area, the screenreader does not announce the hint text

**How**
Added the hint to the text area mixin's aria-describedby attribute

**Test**
Published hof beta and tested on the ETA service in local as well as branch