### PR TITLE
ETA-111 - fix GTM setup (HOTFIX)

### DIFF
--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -22,7 +22,20 @@ const defaults = {
   env: process.env.NODE_ENV || 'development',
   gaTagId: process.env.GA_TAG || 'Test-GA-Tag',
   ga4TagId: process.env.GA_4_TAG,
-  gtmTagId: process.env.GTM_TAG || false,
+  // added to allow support for multiple HOF forms using GTM to customize how they track page views
+  gtm: {
+    tagId: process.env.GTM_TAG || false,
+    config: {},
+    composePageName: function (page, convertPage, serviceName) {
+      switch (serviceName) {
+        case 'ETA':
+          return 'ETA | Customer Contact | ' + convertPage(page);
+        // Add other services here...
+        default:
+          return convertPage(page);
+      }
+    }
+  },
   gaCrossDomainTrackingTagId: process.env.GDS_CROSS_DOMAIN_GA_TAG,
   loglevel: process.env.LOG_LEVEL || 'info',
   ignoreMiddlewareLogs: ['/healthz'],

--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -26,12 +26,8 @@ const defaults = {
   gtm: {
     tagId: process.env.GTM_TAG || false,
     config: {},
-    composePageName: function (page, convertPage, serviceName) {
-      switch (serviceName) {
-        // Add other services here...
-        default:
-          return convertPage(page);
-      }
+    composePageName: function (page, convertPage) {
+      return convertPage(page);
     }
   },
   gaCrossDomainTrackingTagId: process.env.GDS_CROSS_DOMAIN_GA_TAG,

--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -28,8 +28,6 @@ const defaults = {
     config: {},
     composePageName: function (page, convertPage, serviceName) {
       switch (serviceName) {
-        case 'ETA':
-          return 'ETA | Customer Contact | ' + convertPage(page);
         // Add other services here...
         default:
           return convertPage(page);

--- a/frontend/template-partials/views/partials/head.html
+++ b/frontend/template-partials/views/partials/head.html
@@ -3,12 +3,9 @@
 <!-- Google Tag Manager Data Layer  -->
 <script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
   var dataLayer = window.dataLayer || [];
-  dataLayer.push({
-    'event': '{{pageEvent}}',
-    'pageName': '{{pageName}}',
-    'applicationType': '{{applicationType}}',
-    'environmentType': '{{environmentType}}'
-  });
+  dataLayer.push(
+    {{{gtmConfig}}}
+  );
 </script>
 <!-- End Google Tag Manager Data Layer  -->
 

--- a/frontend/template-partials/views/partials/head.html
+++ b/frontend/template-partials/views/partials/head.html
@@ -1,18 +1,16 @@
 {{#gtmTagId}}
 {{#cookiesAccepted}}
-{{#isETA}}
-<!-- Google Tag Manager Data Layer for ETA -->
+<!-- Google Tag Manager Data Layer  -->
 <script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
   var dataLayer = window.dataLayer || [];
   dataLayer.push({
-    'event': 'pageLoad',
-    'pageName': 'ETA | Customer Contact Webform | {{gtm-page}}',
-    'applicationType': 'ETA | Customer Contact',
+    'event': '{{pageEvent}}',
+    'pageName': '{{pageName}}',
+    'applicationType': '{{applicationType}}',
     'environmentType': '{{environmentType}}'
   });
 </script>
-<!-- End Google Tag Manager Data Layer for ETA -->
-{{/isETA}}
+<!-- End Google Tag Manager Data Layer  -->
 
 <!-- Google Tag Manager -->
 <script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>

--- a/lib/ga-tag.js
+++ b/lib/ga-tag.js
@@ -63,7 +63,7 @@ module.exports = (app, config) => {
     app.use((req, res, next) => {
       const page = pageView(req.path, pageMap);
       res.locals.gaAllowDebug = config.env === 'development';
-      res.locals.isETA = config.appName === 'ETA';
+      res.locals.isETA = config.appName.includes('ETA');
       res.locals.gaTagId = gaTagId;
       res.locals.ga4TagId = ga4TagId;
       res.locals.gtmTagId = gtmTagId;

--- a/lib/ga-tag.js
+++ b/lib/ga-tag.js
@@ -78,7 +78,7 @@ module.exports = (app, config) => {
         Object.assign(properties, {
           gtmTagId: gtmTagId,
           'gtm-page': convertToGTMPage(page),
-          eventName: 'pageLoad',
+          pageEvent: 'pageLoad',
           pageName: `ETA | Customer Contact Webform | ${convertToGTMPage(page)}`,
           applicationType: 'ETA | Customer Contact',
           environmentType: environmentType
@@ -89,32 +89,6 @@ module.exports = (app, config) => {
       next();
     });
   }
-
-  /*
-   if (gaTagId || ga4TagId || gtmTagId) {
-    const pageMap = setupPageMap(routes);
-
-    app.use((req, res, next) => {
-      const page = pageView(req.path, pageMap);
-      res.locals.gaAllowDebug = config.env === 'development';
-
-      if (gtmTagId) {
-        res.locals.gtmTagId = gtmTagId;
-        res.locals['gtm-page'] = convertToGTMPage(page);
-        res.locals.eventName = "pageLoad"
-        res.locals.pageName = `ETA | Customer Contact Webform | ${res.locals['gtm-page']}`
-        res.locals.applicationType = "ETA | Customer Contact"
-        res.locals.environmentType = environmentType;
-      }
-      res.locals.gaTagId = gaTagId;
-      res.locals.ga4TagId = ga4TagId;
-      res.locals.gaCrossDomainTrackingTagId = gaCrossDomainTrackingTagId;
-      res.locals['ga-id'] = gaTagId;
-      res.locals['ga-page'] = page;
-      next();
-    });
-  }
-  */
 
   return app;
 };

--- a/lib/ga-tag.js
+++ b/lib/ga-tag.js
@@ -52,12 +52,11 @@ const setupPageMap = routes => {
 module.exports = (app, config) => {
   const gaTagId = config.gaTagId;
   const ga4TagId = config.ga4TagId;
-  const gtmTagId = config.gtmTagId;
-  const environmentType = config.environmentType ? config.environmentType : 'dev';
+  const gtm = config.gtm;
   const gaCrossDomainTrackingTagId = config.gaCrossDomainTrackingTagId;
   const routes = config.routes;
 
-  if (gaTagId || ga4TagId || gtmTagId) {
+  if (gaTagId || ga4TagId || gtm.tagId) {
     const pageMap = setupPageMap(routes);
 
     app.use((req, res, next) => {
@@ -74,17 +73,13 @@ module.exports = (app, config) => {
       };
 
       // Adding extra properties if a GTM TAG is available
-      if (gtmTagId) {
+      if (gtm.tagId) {
+        gtm.config.pageName = gtm.composePageName(page, convertToGTMPage);
         Object.assign(properties, {
-          gtmTagId: gtmTagId,
-          'gtm-page': convertToGTMPage(page),
-          pageEvent: 'pageLoad',
-          pageName: `ETA | Customer Contact Webform | ${convertToGTMPage(page)}`,
-          applicationType: 'ETA | Customer Contact',
-          environmentType: environmentType
+          gtmConfig: JSON.stringify(gtm.config),
+          gtmTagId: gtm.tagId
         });
       }
-
       res.locals = Object.assign(res.locals, properties);
       next();
     });

--- a/lib/ga-tag.js
+++ b/lib/ga-tag.js
@@ -57,24 +57,64 @@ module.exports = (app, config) => {
   const gaCrossDomainTrackingTagId = config.gaCrossDomainTrackingTagId;
   const routes = config.routes;
 
-  if (gaTagId || ga4TagId) {
+  if (gaTagId || ga4TagId || gtmTagId) {
+    const pageMap = setupPageMap(routes);
+
+    app.use((req, res, next) => {
+      const page = pageView(req.path, pageMap);
+
+      // Preparing common res.locals properties
+      const properties = {
+        gaAllowDebug: config.env === 'development',
+        gaTagId: gaTagId,
+        ga4TagId: ga4TagId,
+        gaCrossDomainTrackingTagId: gaCrossDomainTrackingTagId,
+        'ga-id': gaTagId,
+        'ga-page': page
+      };
+
+      // Adding extra properties if a GTM TAG is available
+      if (gtmTagId) {
+        Object.assign(properties, {
+          gtmTagId: gtmTagId,
+          'gtm-page': convertToGTMPage(page),
+          eventName: 'pageLoad',
+          pageName: `ETA | Customer Contact Webform | ${convertToGTMPage(page)}`,
+          applicationType: 'ETA | Customer Contact',
+          environmentType: environmentType
+        });
+      }
+
+      res.locals = Object.assign(res.locals, properties);
+      next();
+    });
+  }
+
+  /*
+   if (gaTagId || ga4TagId || gtmTagId) {
     const pageMap = setupPageMap(routes);
 
     app.use((req, res, next) => {
       const page = pageView(req.path, pageMap);
       res.locals.gaAllowDebug = config.env === 'development';
-      res.locals.isETA = config.appName.includes('ETA');
+
+      if (gtmTagId) {
+        res.locals.gtmTagId = gtmTagId;
+        res.locals['gtm-page'] = convertToGTMPage(page);
+        res.locals.eventName = "pageLoad"
+        res.locals.pageName = `ETA | Customer Contact Webform | ${res.locals['gtm-page']}`
+        res.locals.applicationType = "ETA | Customer Contact"
+        res.locals.environmentType = environmentType;
+      }
       res.locals.gaTagId = gaTagId;
       res.locals.ga4TagId = ga4TagId;
-      res.locals.gtmTagId = gtmTagId;
-      res.locals.environmentType = environmentType;
       res.locals.gaCrossDomainTrackingTagId = gaCrossDomainTrackingTagId;
       res.locals['ga-id'] = gaTagId;
       res.locals['ga-page'] = page;
-      res.locals['gtm-page'] = convertToGTMPage(page);
       next();
     });
   }
+  */
 
   return app;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.3.6-beta-gtm",
+  "version": "20.3.7-beta-gtm",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.3.4",
+  "version": "20.3.6-beta-gtm",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.3.7-beta-gtm",
+  "version": "20.3.8-beta-gtm",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.3.8-beta-gtm",
+  "version": "20.3.4",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",

--- a/test/integration/bootstrap.spec.js
+++ b/test/integration/bootstrap.spec.js
@@ -4,6 +4,9 @@
 const testTag = 'Test-GA-Tag';
 process.env.GA_TAG = testTag;
 
+const testGtmTag = 'Test-GTM-Tag';
+process.env.GTM_TAG = testGtmTag;
+
 const bootstrap = require('../../');
 
 const path = require('path');

--- a/test/integration/server.spec.js
+++ b/test/integration/server.spec.js
@@ -4,8 +4,8 @@ const request = require('supertest');
 const _ = require('lodash');
 const redis = require('redis');
 
-const testGaTag = 'Test-GA-Tag';
-process.env.GA_TAG = testGaTag;
+const testTag = 'Test-GA-Tag';
+process.env.GA_TAG = testTag;
 
 const testGtmTag = 'Test-GTM-Tag';
 process.env.GTM_TAG = testGtmTag;
@@ -644,7 +644,7 @@ describe('hof server', () => {
           }]
         });
         bs.use((req, res) => {
-          res.json({respondedFromMiddleware: true});
+          res.json({ respondedFromMiddleware: true });
         });
         bs.start();
         return request(bs.server)
@@ -796,9 +796,6 @@ describe('hof server', () => {
       bs = bootstrap({
         port: 8888,
         fields: 'fields',
-        gtm: {
-          tagId: testGtmTag
-        },
         routes: [
           {
             views: `${root}/apps/app_1/views`,
@@ -824,6 +821,7 @@ describe('hof server', () => {
           }
         ]
       });
+
       bs.use((req, res) => {
         locals = res.locals;
         res.json({});
@@ -836,19 +834,18 @@ describe('hof server', () => {
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
         .expect(() => {
-          locals.gaTagId.should.equal(testGaTag);
-          locals['ga-id'].should.equal(testGaTag);
+          locals.gaTagId.should.equal(testTag);
+          locals['ga-id'].should.equal(testTag);
           locals['ga-page'].should.equal('feedback');
-        })
-      );
+        }));
 
       it('adds ga-id and ga-page based on baseUrl only', () => request(bs.server)
         .get('/accept')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
         .expect(() => {
-          locals.gaTagId.should.equal(testGaTag);
-          locals['ga-id'].should.equal(testGaTag);
+          locals.gaTagId.should.equal(testTag);
+          locals['ga-id'].should.equal(testTag);
           locals['ga-page'].should.equal('accept');
         }));
 
@@ -857,8 +854,8 @@ describe('hof server', () => {
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
         .expect(() => {
-          locals.gaTagId.should.equal(testGaTag);
-          locals['ga-id'].should.equal(testGaTag);
+          locals.gaTagId.should.equal(testTag);
+          locals['ga-id'].should.equal(testTag);
           locals['ga-page'].should.equal('acceptConfirmPersonConfirmation');
         }));
 
@@ -867,8 +864,8 @@ describe('hof server', () => {
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
         .expect(() => {
-          locals.gaTagId.should.equal(testGaTag);
-          locals['ga-id'].should.equal(testGaTag);
+          locals.gaTagId.should.equal(testTag);
+          locals['ga-id'].should.equal(testTag);
           locals['ga-page'].should.equal('applyIndexStart');
         }));
 
@@ -877,15 +874,15 @@ describe('hof server', () => {
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
         .expect(() => {
-          locals.gaTagId.should.equal(testGaTag);
-          locals['ga-id'].should.equal(testGaTag);
+          locals.gaTagId.should.equal(testTag);
+          locals['ga-id'].should.equal(testTag);
           locals['ga-page'].should.equal('applyConfirmEndSubmitEnd');
         }));
     });
 
     describe('with gtm-tag', () => {
       it('adds gtm tagId and gtm pageName based on root uri', () => {
-        let gtmApp = bootstrap({
+        const gtmApp = bootstrap({
           port: 8888,
           fields: 'fields',
           gtm: {
@@ -925,117 +922,117 @@ describe('hof server', () => {
           .set('Cookie', ['myCookie=1234'])
           .expect(200)
           .expect(() => {
-            locals.gtmTagId.should.equal(testGtmTag)
+            locals.gtmTagId.should.equal(testGtmTag);
             locals['ga-page'].should.equal('feedback');
           });
-      })
+      });
 
       it('pass custom gtm config for gtm data layer', () => {
-          let gtmApp = bootstrap({
-            port: 8888,
-            fields: 'fields',
-            gtm: {
-              tagId: testGtmTag,
-              config: {
-                event: 'pageLoad',
-                applicationType: 'Web',
-                environmentType: 'dev'
+        const gtmApp = bootstrap({
+          port: 8888,
+          fields: 'fields',
+          gtm: {
+            tagId: testGtmTag,
+            config: {
+              event: 'pageLoad',
+              applicationType: 'Web',
+              environmentType: 'dev'
+            }
+          },
+          routes: [
+            {
+              views: `${root}/apps/app_1/views`,
+              steps: {
+                '/feedback': {}
               }
             },
-            routes: [
-              {
-                views: `${root}/apps/app_1/views`,
-                steps: {
-                  '/feedback': {}
-                }
-              },
-              {
-                views: `${root}/apps/app_1/views`,
-                baseUrl: '/accept',
-                steps: {
-                  '/': {},
-                  '/confirm/person/confirmation': {}
-                }
-              },
-              {
-                views: `${root}/apps/app_1/views`,
-                baseUrl: '/apply',
-                steps: {
-                  '/index-start': {},
-                  '/confirm-end/submit-end': {}
-                }
+            {
+              views: `${root}/apps/app_1/views`,
+              baseUrl: '/accept',
+              steps: {
+                '/': {},
+                '/confirm/person/confirmation': {}
               }
-            ]
+            },
+            {
+              views: `${root}/apps/app_1/views`,
+              baseUrl: '/apply',
+              steps: {
+                '/index-start': {},
+                '/confirm-end/submit-end': {}
+              }
+            }
+          ]
+        });
+        gtmApp.use((req, res) => {
+          locals = res.locals;
+          res.json({});
+        });
+        return request(gtmApp.server)
+          .get('/feedback')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(200)
+          .expect(() => {
+            locals.gtmTagId.should.equal(testGtmTag);
+            JSON.parse(locals.gtmConfig).pageName = 'Feedback';
+            JSON.parse(locals.gtmConfig).event = 'pageLoad';
+            JSON.parse(locals.gtmConfig).applicationType = 'Web';
+            JSON.parse(locals.gtmConfig).environmentType = 'dev';
           });
-          gtmApp.use((req, res) => {
-            locals = res.locals;
-            res.json({});
-          });
-          return request(gtmApp.server)
-            .get('/feedback')
-            .set('Cookie', ['myCookie=1234'])
-            .expect(200)
-            .expect(() => {
-              locals.gtmTagId.should.equal(testGtmTag)
-              JSON.parse(locals.gtmConfig)["pageName"] = "Feedback"
-              JSON.parse(locals.gtmConfig)["event"] = "pageLoad"
-              JSON.parse(locals.gtmConfig)["applicationType"] = "Web"
-              JSON.parse(locals.gtmConfig)["environmentType"] = "dev"
-            });
-        }
+      }
       );
 
       it('override composePageName function for generating custom pageName layouts', () => {
-          let gtmApp = bootstrap({
-            port: 8888,
-            fields: 'fields',
-            gtm: {
-              tagId: testGtmTag,
-              composePageName: function (page, convertPage) {
-                return "Custom Prefix" + convertPage(page)
+        const gtmApp = bootstrap({
+          port: 8888,
+          fields: 'fields',
+          gtm: {
+            tagId: testGtmTag,
+            composePageName: function (page, convertPage) {
+              return 'Custom Prefix' + convertPage(page);
+            }
+          },
+          routes: [
+            {
+              views: `${root}/apps/app_1/views`,
+              steps: {
+                '/feedback': {}
               }
             },
-            routes: [
-              {
-                views: `${root}/apps/app_1/views`,
-                steps: {
-                  '/feedback': {}
-                }
-              },
-              {
-                views: `${root}/apps/app_1/views`,
-                baseUrl: '/accept',
-                steps: {
-                  '/': {},
-                  '/confirm/person/confirmation': {}
-                }
-              },
-              {
-                views: `${root}/apps/app_1/views`,
-                baseUrl: '/apply',
-                steps: {
-                  '/index-start': {},
-                  '/confirm-end/submit-end': {}
-                }
+            {
+              views: `${root}/apps/app_1/views`,
+              baseUrl: '/accept',
+              steps: {
+                '/': {},
+                '/confirm/person/confirmation': {}
               }
-            ]
+            },
+            {
+              views: `${root}/apps/app_1/views`,
+              baseUrl: '/apply',
+              steps: {
+                '/index-start': {},
+                '/confirm-end/submit-end': {}
+              }
+            }
+          ]
+        });
+        gtmApp.use((req, res) => {
+          locals = res.locals;
+          res.json({});
+        });
+        return request(gtmApp.server)
+          .get('/feedback')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(200)
+          .expect(() => {
+            locals.gtmTagId.should.equal(testGtmTag);
+            locals['ga-page'].should.equal('feedback');
+            JSON.parse(locals.gtmConfig).pageName = 'Custom Prefix Feedback';
           });
-          gtmApp.use((req, res) => {
-            locals = res.locals;
-            res.json({});
-          });
-          return request(gtmApp.server)
-            .get('/feedback')
-            .set('Cookie', ['myCookie=1234'])
-            .expect(200)
-            .expect(() => {
-              locals.gtmTagId.should.equal(testGtmTag)
-              locals['ga-page'].should.equal('feedback');
-              JSON.parse(locals.gtmConfig)["pageName"] = "Custom Prefix Feedback"
-            });
-        }
+      }
       );
-    })
+    });
 
     describe('with nonce values', () => {
       it('adds a 16 figure hex nonce value to locals', () => request(bs.server)


### PR DESCRIPTION
## What?
- Updated ETA verification logic for Google Tag Manager (GTM) dataLayer.
- https://collaboration.homeoffice.gov.uk/jira/browse/ETA-111

## Why?
- Previously, an exact match with the appName 'ETA' was required for adding dataLayer snippet. This was not the best approach because the business requested for the appName to be changed to "Ask a question about ETA" which stopped GTM monitoring

## How?
- GTM dataLayer snippet no longer relies on appName, only relies on a GTM TAG present in the hof config
- Added dynamic config object 'gtmConfig' to manage what payload is input into the dataLayer

## Testing?
- Created beta version of hof package and tested in branch environment 
- All acceptance + unit tests passing
- Branch for testing: https://github.com/UKHomeOffice/eta/pull/48