### PR TITLE
HOFF-593- add more information to 404 error page not found

### DIFF
--- a/frontend/template-partials/translations/src/en/errors.json
+++ b/frontend/template-partials/translations/src/en/errors.json
@@ -9,12 +9,7 @@
   },
   "404": {
     "title": "Page not found",
-    "description": "This page does not exist",
-    "paragraph1": "If you typed the web address, check it is correct.",
-    "paragraph2": "If you pasted the web address, check you copied the entire address.",
-    "paragraph3": "If the web address is correct or you selected a link or button,",
-    "paragraph3sub": "if you need to speak to someone about your tax credits.",
-    "referencetag": "contact the Tax Credits Helpline"
+    "description": "This page does not exist"
   },
   "cookies-required": {
     "title": "Cookies are required to use this service",

--- a/frontend/template-partials/translations/src/en/errors.json
+++ b/frontend/template-partials/translations/src/en/errors.json
@@ -9,7 +9,12 @@
   },
   "404": {
     "title": "Page not found",
-    "description": "This page does not exist"
+    "description": "This page does not exist",
+    "paragraph1": "If you typed the web address, check it is correct.",
+    "paragraph2": "If you pasted the web address, check you copied the entire address.",
+    "paragraph3": "If the web address is correct or you selected a link or button,",
+    "paragraph3sub": "if you need to speak to someone about your tax credits.",
+    "referencetag": "contact the Tax Credits Helpline"
   },
   "cookies-required": {
     "title": "Cookies are required to use this service",

--- a/frontend/template-partials/views/404.html
+++ b/frontend/template-partials/views/404.html
@@ -1,9 +1,25 @@
 {{<layout}}
-  {{$header}}
-    {{title}}
-  {{/header}}
+  
+  {{$header}}  {{title}}  {{/header}}
+  
   {{$content}}
-    <p>{{description}}</p>
-    <a href="/" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">{{title}}</h1>
+              <p class="govuk-body">
+              {{paragraph1}}
+              </p>
+              <p class="govuk-body">
+                {{paragraph2}}
+              </p>
+              <p class="govuk-body">
+                {{paragraph3}} <a href="#" class="govuk-link">{{referencetag}}</a> {{paragraph3sub}}
+              </p>
+          </div>
+        </div>
+      </main>
+    </div>
   {{/content}}
 {{/layout}}

--- a/frontend/template-partials/views/404.html
+++ b/frontend/template-partials/views/404.html
@@ -9,13 +9,13 @@
           <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">{{title}}</h1>
               <p class="govuk-body">
-              {{paragraph1}}
+                If you typed the web address, check it is correct.
               </p>
               <p class="govuk-body">
-                {{paragraph2}}
+                If you pasted the web address, check you copied the entire address.
               </p>
               <p class="govuk-body">
-                {{paragraph3}} <a href="#" class="govuk-link">{{referencetag}}</a> {{paragraph3sub}}
+                If the web address is correct or you selected a link or button, <a href="#" class="govuk-link">contact the HOF Team</a>.
               </p>
           </div>
         </div>

--- a/middleware/not-found.js
+++ b/middleware/not-found.js
@@ -3,21 +3,11 @@
 const getTranslations = translate => {
   const translations = {
     title: 'Not found',
-    description: 'There is nothing here',
-    paragraph1: '',
-    paragraph2: '',
-    paragraph3: '',
-    paragraph3sub: '',
-    referencetag: ''
+    description: 'There is nothing here'
   };
   if (translate) {
     translations.title = translate('errors.404.title');
     translations.description = translate('errors.404.description');
-    translations.paragraph1 = translate('errors.404.paragraph1');
-    translations.paragraph2 = translate('errors.404.paragraph2');
-    translations.paragraph3 = translate('errors.404.paragraph3');
-    translations.paragraph3sub = translate('errors.404.paragraph3sub');
-    translations.referencetag = translate('errors.404.referencetag');
   }
   return translations;
 };
@@ -36,11 +26,6 @@ module.exports = options => {
     res.status(404).render('404', {
       title: translations.title,
       description: translations.description,
-      paragraph1: translations.paragraph1,
-      paragraph2: translations.paragraph2,
-      paragraph3: translations.paragraph3,
-      paragraph3sub: translations.paragraph3sub,
-      referencetag: translations.referencetag,
       // Finds the first word in the path of the
       // url and removes the leading slash.
       // Where url is `/foo/bar`, this returns `foo`.

--- a/middleware/not-found.js
+++ b/middleware/not-found.js
@@ -3,14 +3,22 @@
 const getTranslations = translate => {
   const translations = {
     title: 'Not found',
-    description: 'There is nothing here'
+    description: 'There is nothing here',
+    paragraph1: '',
+    paragraph2: '',
+    paragraph3: '',
+    paragraph3sub: '',
+    referencetag: ''
   };
-
   if (translate) {
     translations.title = translate('errors.404.title');
     translations.description = translate('errors.404.description');
+    translations.paragraph1 = translate('errors.404.paragraph1');
+    translations.paragraph2 = translate('errors.404.paragraph2');
+    translations.paragraph3 = translate('errors.404.paragraph3');
+    translations.paragraph3sub = translate('errors.404.paragraph3sub');
+    translations.referencetag = translate('errors.404.referencetag');
   }
-
   return translations;
 };
 
@@ -25,10 +33,14 @@ module.exports = options => {
     if (logger && logger.warn) {
       logger.warn(`Cannot find: ${req.url}`);
     }
-
     res.status(404).render('404', {
       title: translations.title,
       description: translations.description,
+      paragraph1: translations.paragraph1,
+      paragraph2: translations.paragraph2,
+      paragraph3: translations.paragraph3,
+      paragraph3sub: translations.paragraph3sub,
+      referencetag: translations.referencetag,
       // Finds the first word in the path of the
       // url and removes the leading slash.
       // Where url is `/foo/bar`, this returns `foo`.


### PR DESCRIPTION
## What 
[HOFF-593](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-593) Adding content to 404 error page
## Why
To follow the GDS standard for 404 error page 
## How 
-  research the design system from [Gov.uk](https://design-system.service.gov.uk/patterns/page-not-found-pages)
-  added content to 404.html page

## Test
Tested locally 