### PR TITLE
HOFF-594 Implement internal server error page (500 status code)

### DIFF
--- a/components/address-lookup/index.js
+++ b/components/address-lookup/index.js
@@ -230,7 +230,7 @@ module.exports = config => {
                 }, req, res)
               };
             // cannot connect to validation service, skip api validation
-            } else if (err.status === 403 || err.status === 404) {
+            } else if (err.status === 403 || err.status === 404 || err.status === 500) {
               return super.validate(req, res, callback);
             }
             return callback(err);

--- a/frontend/template-partials/translations/src/en/errors.json
+++ b/frontend/template-partials/translations/src/en/errors.json
@@ -11,6 +11,14 @@
     "title": "Page not found",
     "description": "This page does not exist"
   },
+  "500": {
+    "title": "Internal Server Error",
+    "description": "Server is down",
+    "header": "Sorry, there is a problem with the service",
+    "paragraph1": "Try again later.",
+    "paragraph2": "We saved your answers. They will be available for 30 days.",
+    "paragraph3": "if you need to make changes to your claim or speak to someone about your application."
+  },
   "cookies-required": {
     "title": "Cookies are required to use this service",
     "message": "Cookies are required in order to use this service.<br /><br /> Please <a href=\"http://www.aboutcookies.org/how-to-control-cookies/\" rel=\"external\">enable cookies</a> and try again. Find out <a href=\"/cookies\">how to we use cookies</a>."

--- a/frontend/template-partials/translations/src/en/errors.json
+++ b/frontend/template-partials/translations/src/en/errors.json
@@ -15,9 +15,7 @@
     "title": "Internal Server Error",
     "description": "Server is down",
     "header": "Sorry, there is a problem with the service",
-    "paragraph1": "Try again later.",
-    "paragraph2": "We saved your answers. They will be available for 30 days.",
-    "paragraph3": "if you need to make changes to your claim or speak to someone about your application."
+    "paragraph1": "Try again later."
   },
   "cookies-required": {
     "title": "Cookies are required to use this service",

--- a/frontend/template-partials/translations/src/en/errors.json
+++ b/frontend/template-partials/translations/src/en/errors.json
@@ -13,9 +13,7 @@
   },
   "500": {
     "title": "Internal Server Error",
-    "description": "Server is down",
-    "header": "Sorry, there is a problem with the service",
-    "paragraph1": "Try again later."
+    "description": "Server is down"
   },
   "cookies-required": {
     "title": "Cookies are required to use this service",

--- a/frontend/template-partials/views/500.html
+++ b/frontend/template-partials/views/500.html
@@ -8,8 +8,8 @@
         <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-              <h1 class="govuk-heading-l"> {{content.header}} </h1>
-              <p class="govuk-body"> {{content.paragraph1}} </p>
+              <h1 class="govuk-heading-l"> Sorry, there is a problem with the service </h1>
+              <p class="govuk-body"> Try again later. </p>
             </div>
           </div>
         </main>

--- a/frontend/template-partials/views/500.html
+++ b/frontend/template-partials/views/500.html
@@ -10,10 +10,6 @@
             <div class="govuk-grid-column-two-thirds">
               <h1 class="govuk-heading-l"> {{content.header}} </h1>
               <p class="govuk-body"> {{content.paragraph1}} </p>
-              <p class="govuk-body"> {{content.paragraph2}} </p>
-              <p class="govuk-body">
-                <a class="govuk-link" href="#">Contact the HOF Team</a> {{content.paragraph3}}
-              </p>
             </div>
           </div>
         </main>

--- a/frontend/template-partials/views/500.html
+++ b/frontend/template-partials/views/500.html
@@ -1,0 +1,23 @@
+{{<layout}}
+  {{$header}}
+    {{title}}
+  {{/header}}
+  {{$content}}
+  
+      <div class="govuk-width-container">
+        <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <h1 class="govuk-heading-l"> {{content.header}} </h1>
+              <p class="govuk-body"> {{content.paragraph1}} </p>
+              <p class="govuk-body"> {{content.paragraph2}} </p>
+              <p class="govuk-body">
+                <a class="govuk-link" href="#">Contact the HOF Team</a> {{content.paragraph3}}
+              </p>
+            </div>
+          </div>
+        </main>
+      </div>
+    <a href="/" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
+  {{/content}}
+{{/layout}}

--- a/index.js
+++ b/index.js
@@ -53,7 +53,6 @@ const applyErrorMiddlewares = (app, config) => {
   app.use(hofMiddleware.notFound({
     logger: config.logger
   }));
-
   app.use(hofMiddleware.errors({
     logger: config.logger,
     debug: config.env === 'development'

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -8,7 +8,7 @@ const errorMsg = code => `There is a ${code}_ERROR`;
 // eslint-disable-next-line complexity
 const getContent = (err, translate) => {
   const content = {};
-
+  
   if (err.code === 'SESSION_TIMEOUT') {
     err.status = 401;
     err.template = 'session-timeout';
@@ -17,14 +17,14 @@ const getContent = (err, translate) => {
     content.title = (translate && translate('errors.session.title'));
     content.message = (translate && translate('errors.session.message'));
   }
-
+  
   if (err.code === 'NO_COOKIES') {
     err.status = 403;
     err.template = 'cookie-error';
     content.title = (translate && translate('errors.cookies-required.title'));
     content.message = (translate && translate('errors.cookies-required.message'));
   }
-
+  
   if (err.code === 'DDOS_RATE_LIMIT') {
     err.status = 429;
     err.template = 'rate-limit-error';
@@ -39,7 +39,7 @@ const getContent = (err, translate) => {
     content.timeToWait = rateLimitsConfig.rateLimits.requests.windowSizeInMinutes;
     content.postTimeToWait = (translate && translate('errors.ddos-rate-limit.post-time-to-wait'));
   }
-
+  
   if (err.code === 'SUBMISSION_RATE_LIMIT') {
     err.status = 429;
     err.template = 'rate-limit-error';
@@ -54,10 +54,25 @@ const getContent = (err, translate) => {
     content.timeToWait = rateLimitsConfig.rateLimits.submissions.windowSizeInMinutes;
     content.postTimeToWait = (translate && translate('errors.submission-rate-limit.post-time-to-wait'));
   }
-
-  err.code = err.code || 'UNKNOWN';
-  err.status = err.status || 500;
-
+  
+  if (err.code === 'INTERNAL_SERVER_ERROR' || err.code === 'UNKNOWN') {
+    err.status = err.status || 500;
+    err.template = '500';
+    err.title = (translate && translate('errors.500.title'));
+    err.message = (translate && translate('errors.500.description'));
+    err.header = (translate && translate('errors.500.header'));
+    err.paragraph1 = (translate && translate('errors.500.paragraph1'));
+    err.paragraph2 = (translate && translate('errors.500.paragraph2'));
+    err.paragraph3 = (translate && translate('errors.500.paragraph3'));
+    content.title = (translate && translate('errors.500.title'));
+    content.message = (translate && translate('errors.500.description'));
+    content.header = (translate && translate('errors.500.header'));
+    content.paragraph1 = (translate && translate('errors.500.paragraph1'));
+    content.paragraph2 = (translate && translate('errors.500.paragraph2'));
+    content.paragraph3 = (translate && translate('errors.500.paragraph3'));
+  }
+  
+  
   if (!content.title) {
     content.title = (translate && translate('errors.default.title')) || errorTitle(err.code);
   }

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -55,12 +55,8 @@ const getContent = (err, translate) => {
     err.template = '500';
     err.title = (translate && translate('errors.500.title'));
     err.message = (translate && translate('errors.500.description'));
-    err.header = (translate && translate('errors.500.header'));
-    err.paragraph1 = (translate && translate('errors.500.paragraph1'));
     content.title = (translate && translate('errors.500.title'));
     content.message = (translate && translate('errors.500.description'));
-    content.header = (translate && translate('errors.500.header'));
-    content.paragraph1 = (translate && translate('errors.500.paragraph1'));
   }
   if (!content.title) {
     content.title = (translate && translate('errors.default.title')) || errorTitle(err.code);
@@ -83,7 +79,6 @@ module.exports = options => {
   const opts = options || {};
   const logger = opts.logger;
   const debug = opts.debug;
-
   return (err, req, res, next) => {
     const translate = opts.translate || req.translate;
     const content = getContent(err, translate);

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -8,7 +8,6 @@ const errorMsg = code => `There is a ${code}_ERROR`;
 // eslint-disable-next-line complexity
 const getContent = (err, translate) => {
   const content = {};
-  
   if (err.code === 'SESSION_TIMEOUT') {
     err.status = 401;
     err.template = 'session-timeout';
@@ -17,14 +16,12 @@ const getContent = (err, translate) => {
     content.title = (translate && translate('errors.session.title'));
     content.message = (translate && translate('errors.session.message'));
   }
-  
   if (err.code === 'NO_COOKIES') {
     err.status = 403;
     err.template = 'cookie-error';
     content.title = (translate && translate('errors.cookies-required.title'));
     content.message = (translate && translate('errors.cookies-required.message'));
   }
-  
   if (err.code === 'DDOS_RATE_LIMIT') {
     err.status = 429;
     err.template = 'rate-limit-error';
@@ -39,7 +36,6 @@ const getContent = (err, translate) => {
     content.timeToWait = rateLimitsConfig.rateLimits.requests.windowSizeInMinutes;
     content.postTimeToWait = (translate && translate('errors.ddos-rate-limit.post-time-to-wait'));
   }
-  
   if (err.code === 'SUBMISSION_RATE_LIMIT') {
     err.status = 429;
     err.template = 'rate-limit-error';
@@ -54,7 +50,6 @@ const getContent = (err, translate) => {
     content.timeToWait = rateLimitsConfig.rateLimits.submissions.windowSizeInMinutes;
     content.postTimeToWait = (translate && translate('errors.submission-rate-limit.post-time-to-wait'));
   }
-  
   if (err.code === 'UNKNOWN' || err.code === 'INTERNAL_SERVER_ERROR') {
     err.status = 500;
     err.template = '500';
@@ -71,8 +66,6 @@ const getContent = (err, translate) => {
     content.paragraph2 = (translate && translate('errors.500.paragraph2'));
     content.paragraph3 = (translate && translate('errors.500.paragraph3'));
   }
-  
-  
   if (!content.title) {
     content.title = (translate && translate('errors.default.title')) || errorTitle(err.code);
   }

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -55,8 +55,8 @@ const getContent = (err, translate) => {
     content.postTimeToWait = (translate && translate('errors.submission-rate-limit.post-time-to-wait'));
   }
   
-  if (err.code === 'INTERNAL_SERVER_ERROR' || err.code === 'UNKNOWN') {
-    err.status = err.status || 500;
+  if (err.code === 'UNKNOWN' || err.code === 'INTERNAL_SERVER_ERROR') {
+    err.status = 500;
     err.template = '500';
     err.title = (translate && translate('errors.500.title'));
     err.message = (translate && translate('errors.500.description'));

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -57,14 +57,10 @@ const getContent = (err, translate) => {
     err.message = (translate && translate('errors.500.description'));
     err.header = (translate && translate('errors.500.header'));
     err.paragraph1 = (translate && translate('errors.500.paragraph1'));
-    err.paragraph2 = (translate && translate('errors.500.paragraph2'));
-    err.paragraph3 = (translate && translate('errors.500.paragraph3'));
     content.title = (translate && translate('errors.500.title'));
     content.message = (translate && translate('errors.500.description'));
     content.header = (translate && translate('errors.500.header'));
     content.paragraph1 = (translate && translate('errors.500.paragraph1'));
-    content.paragraph2 = (translate && translate('errors.500.paragraph2'));
-    content.paragraph3 = (translate && translate('errors.500.paragraph3'));
   }
   if (!content.title) {
     content.title = (translate && translate('errors.default.title')) || errorTitle(err.code);

--- a/test/middleware/errors.spec.js
+++ b/test/middleware/errors.spec.js
@@ -117,13 +117,13 @@ describe('errors', () => {
         res.render.should.have.been.calledWith('error', sinon.match(locals));
       });
 
-      it('renders the `error` template with `500` status', () => {
+      it('renders the `500` template with `500` status', () => {
         const err = {
           code: 'UNKNOWN'
         };
-
+        
         const locals = {
-          content: {message: 'errors.default.message', title: 'errors.default.title'},
+          content: {message: 'errors.500.description', title: 'errors.500.title'},
           error: err,
           showStack: false,
           startLink: '/'
@@ -132,7 +132,7 @@ describe('errors', () => {
         middleware(err, req, res, next);
 
         res.status.should.have.been.calledWith(500);
-        res.render.should.have.been.calledWith('error', sinon.match(locals));
+        res.render.should.have.been.calledWith('500', sinon.match(locals));
       });
     });
 
@@ -179,13 +179,17 @@ describe('errors', () => {
         res.send.should.have.been.calledWith(html);
       });
 
-      it('renders the `error` template with `500` status for unknown errors', () => {
-        res.render.withArgs('error').yields(null, html);
-
-        const err = new Error('unknown');
+      it('renders the `500` template with `500` status for unknown errors', () => {
+        res.render.withArgs('500').yields(null, html);
+        
+       // const err = new Error('UNKNOWN');
+       
+       const err = {
+        code: 'UNKNOWN'
+      };
 
         const locals = {
-          content: {message: 'errors.default.message', title: 'errors.default.title'},
+          content: {message: 'errors.500.description', title: 'errors.500.title'},
           error: err,
           showStack: false,
           startLink: '/'
@@ -194,7 +198,7 @@ describe('errors', () => {
         middleware(err, req, res, next);
 
         res.status.should.have.been.calledWith(500);
-        res.render.should.have.been.calledWith('error', sinon.match(locals));
+        res.render.should.have.been.calledWith('500', sinon.match(locals));
         res.send.should.have.been.calledWith(html);
       });
     });
@@ -233,15 +237,21 @@ describe('errors', () => {
       });
 
       it('uses a default UNKNOWN title and message when error code is not SESSION_TIMEOUT or NO_COOKIES', () => {
-        const err = new Error('unknown');
+        //const err = new Error('Unknown');
+        
+        const err = {
+          code: 'UNKNOWN'
+        }
+        
 
         const locals = {
           content: {message: 'There is a UNKNOWN_ERROR', title: 'UNKNOWN_ERROR'}
+        // content: {message: 'Server is down', title: 'Internal Server Error'}
         };
-
+        
         middleware(err, req, res, next);
 
-        res.render.should.have.been.calledWith('error', sinon.match(locals));
+        res.render.should.have.been.calledWith('500', sinon.match(locals));
       });
     });
   });

--- a/test/middleware/errors.spec.js
+++ b/test/middleware/errors.spec.js
@@ -121,14 +121,12 @@ describe('errors', () => {
         const err = {
           code: 'UNKNOWN'
         };
-        
         const locals = {
           content: {message: 'errors.500.description', title: 'errors.500.title'},
           error: err,
           showStack: false,
           startLink: '/'
         };
-
         middleware(err, req, res, next);
 
         res.status.should.have.been.calledWith(500);
@@ -171,7 +169,6 @@ describe('errors', () => {
           showStack: false,
           startLink: '/'
         };
-
         middleware(err, req, res, next);
 
         res.status.should.have.been.calledWith(403);
@@ -181,13 +178,9 @@ describe('errors', () => {
 
       it('renders the `500` template with `500` status for unknown errors', () => {
         res.render.withArgs('500').yields(null, html);
-        
-       // const err = new Error('UNKNOWN');
-       
-       const err = {
-        code: 'UNKNOWN'
-      };
-
+        const err = {
+          code: 'UNKNOWN'
+        };
         const locals = {
           content: {message: 'errors.500.description', title: 'errors.500.title'},
           error: err,
@@ -237,18 +230,12 @@ describe('errors', () => {
       });
 
       it('uses a default UNKNOWN title and message when error code is not SESSION_TIMEOUT or NO_COOKIES', () => {
-        //const err = new Error('Unknown');
-        
         const err = {
           code: 'UNKNOWN'
-        }
-        
-
+        };
         const locals = {
           content: {message: 'There is a UNKNOWN_ERROR', title: 'UNKNOWN_ERROR'}
-        // content: {message: 'Server is down', title: 'Internal Server Error'}
         };
-        
         middleware(err, req, res, next);
 
         res.render.should.have.been.calledWith('500', sinon.match(locals));


### PR DESCRIPTION
## What

[HOFF-594](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-594)- HTTP Error 500 (Internal Server Error) Error Page

## Why

To display an error page to users, which follows the Government Design Standard (GDS)

## How 

 - create a 500 error page in the view folder named 500.html, this page content the html element tag of content display
 - add an if block statement to capture the error code (UNKNOWN or INTERNAL_SERVER_ERROR) in the Middleware/errors.js file 
 - add an object of content to display in the Translations.en/errors.json file.

## Testing
Tested locally 
![Screenshot 2024-02-25 at 22 27 45](https://github.com/UKHomeOfficeForms/hof/assets/138882912/2b859897-b02f-4bf0-8068-679c0a050f52)

<img width="935" alt="Screenshot 2024-02-26 at 11 12 05" src="https://github.com/UKHomeOfficeForms/hof/assets/138882912/1928911d-2a87-409f-8c1b-56c39e9daeb1">

