### PR TITLE
HOFF-668 Add PR template

### DIFF
--- a/pull_request.md
+++ b/pull_request.md
@@ -1,0 +1,16 @@
+## What? 
+## Why? 
+## How? 
+## Testing?
+## Screenshots (optional)
+## Anything Else? (optional)
+## Check list
+
+- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
+- [ ] I have written tests (if relevant)
+- [ ] I have created a JIRA number for my branch
+- [ ] I have created a JIRA number for my commit
+- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
+here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
+- [ ] Ensure drone builds are green especially tests
+- [ ] I will squash the commits before merging


### PR DESCRIPTION
## What

Create a pull request template

## Why

* A lot of the developers especially those new are not following the agreed way to create a PR.  
* This will create a template for a PR.  
* This also has a checklist to ensure devs have completed important steps e.g. reviewed their own PR before submitting it to others