### PR TITLE
HOFF-661: Deindex ETA webform

### DIFF
--- a/config/hof-defaults.js
+++ b/config/hof-defaults.js
@@ -30,6 +30,7 @@ const defaults = {
       return convertPage(page);
     }
   },
+  deIndexForm: process.env.DEINDEX_FORM || 'false',
   gaCrossDomainTrackingTagId: process.env.GDS_CROSS_DOMAIN_GA_TAG,
   loglevel: process.env.LOG_LEVEL || 'info',
   ignoreMiddlewareLogs: ['/healthz'],

--- a/frontend/govuk-template/build/govuk_template.html
+++ b/frontend/govuk-template/build/govuk_template.html
@@ -4,6 +4,7 @@
 <!--[if gt IE 8]><!--><html lang="{{ htmlLang }}" class="govuk-template"><!--<![endif]-->
   <head>
     <meta charset="utf-8" />
+    <meta name="robots" content="noindex">
     <title>{{ pageTitle }}</title>
     {{{ head }}}
 

--- a/frontend/govuk-template/build/govuk_template.html
+++ b/frontend/govuk-template/build/govuk_template.html
@@ -4,7 +4,6 @@
 <!--[if gt IE 8]><!--><html lang="{{ htmlLang }}" class="govuk-template"><!--<![endif]-->
   <head>
     <meta charset="utf-8" />
-    <meta name="robots" content="noindex">
     <title>{{ pageTitle }}</title>
     {{{ head }}}
 

--- a/frontend/template-partials/views/partials/head.html
+++ b/frontend/template-partials/views/partials/head.html
@@ -21,5 +21,9 @@
 {{/cookiesAccepted}}
 {{/gtmTagId}}
 
+{{#deIndex}}
+<meta name="robots" content="noindex">
+{{/deIndex}}
+TESTING
 <meta name="format-detection" content="telephone=no">
 <link rel="stylesheet" href="{{assetPath}}/css/app.css">

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const router = require('./lib/router');
 const health = require('./lib/health');
 const serveStatic = require('./lib/serve-static');
 const gaTagSetup = require('./lib/ga-tag');
+const deIndexer = require('./lib/deindex');
 const sessionStore = require('./lib/sessions');
 const settings = require('./lib/settings');
 const defaults = require('./config/hof-defaults');
@@ -198,6 +199,7 @@ function bootstrap(options) {
   serveStatic(app, config);
   settings(app, config);
   gaTagSetup(app, config);
+  deIndexer(app, config);
 
   const sessions = sessionStore(app, config);
   app.use('/healthz', health(sessions));

--- a/lib/deindex.js
+++ b/lib/deindex.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = (app, config) => {
+  const deIndex = config.deIndexForm;
+  console.log("DEINDEX VALUE: " + deIndex);
+
+  app.use((req, res, next) => {
+
+    // Preparing common res.locals properties
+    const properties = {
+      deIndex: deIndex
+    };
+    res.locals = Object.assign(res.locals, properties);
+    next();
+  });
+
+  return app;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.4.3",
+  "version": "20.5.0-beta-deindex-test",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.4.2",
+  "version": "20.4.3",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",
@@ -70,7 +70,6 @@
     "lodash": "^4.17.21",
     "markdown-it": "^12.3.2",
     "minimatch": "^3.0.7",
-    "minimist": "^1.2.6",
     "mixwith": "^0.1.1",
     "moment": "^2.29.4",
     "morgan": "^1.10.0",

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "govuk-frontend": "3.14",
     "jquery": "^3.6.0",
+    "minimist": "^1.2.8",
     "sass": "^1.53.0",
     "typeahead-aria": "^1.0.4"
   },

--- a/sandbox/yarn.lock
+++ b/sandbox/yarn.lock
@@ -142,6 +142,11 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"


### PR DESCRIPTION
## What
De-index the ETA webform - [HOFF-661](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-661) 

## Why
So that it is not returned in browser searches

## How
- Added robots meta tag to /frontend/govuk-template/govuk_template.html, with the content as "noindex"

## Test
Tested locally