### PR TITLE
Add hint property to checkboxes to align with govuk designs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2024-04-24, Version 20.5.0 (Stable), @mislam987
+* Add hint property to checkboxes to align with govuk design guidelines
+
 ## 2024-02-29, Version 20.4.0 (Stable), @sulthan-ahmed
 * Update version of govuk-frontend to 3.15
 - this adds the new crown for the King

--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -319,6 +319,7 @@ module.exports = function (options) {
         error: this.errors && this.errors[key],
         invalid: this.errors && this.errors[key] && opts.required,
         label: t(fieldLabel || 'fields.' + key + '.label'),
+        hint: conditionalTranslate(getTranslationKey(field, key, 'hint')),
         selected: selected,
         className: classNames(field) || 'govuk-label govuk-checkboxes__label',
         child: field.child,

--- a/frontend/template-mixins/partials/forms/checkbox.html
+++ b/frontend/template-mixins/partials/forms/checkbox.html
@@ -6,6 +6,11 @@
             {{{label}}}
             {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
         </label>
+        {{#hint}}
+        <div id="{{key}}-hint" class="govuk-hint govuk-checkboxes__hint">
+          {{hint}}
+        </div>
+        {{/hint}}
     </div>
     {{#renderChild}}{{/renderChild}}
 </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "20.4.5",
+  "version": "20.5.0",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
## What

Add hint property to checkbox in template-mixins and checkbox.html - Relates to [HOFF-648](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-648) (upgrading of HOF version to v20.4.0 for NRM)

## Why

To resolve layout issue of hints within checkbox items when upgrading NRM to use HOF version 20.4.0, ensuring the checkbox items layout aligns with GDS (https://design-system.service.gov.uk/components/checkboxes/)

## How 

- Add 'hint' property to the 'checkbox' function in `hof/frontend/template-mixins/template-mixins.js`
- Add '#hint' section in `hof/frontend/template-mixins/partials/forms/checkbox.html`, with the relevant CSS hint styling from GDS

## Testing

- Tested locally on NRM and IMA
- Tested on branch for NRM

## Screenshots

On branch (NRM):
<img width="974" alt="image" src="https://github.com/UKHomeOfficeForms/hof/assets/142597294/7f2803ad-dc47-42f7-b371-ffcb9a962943">
