### PR TITLE
HOFF-648: Fixed typo causing spacing issues found when updating nrm to latest hof version

### DIFF
--- a/frontend/template-mixins/partials/forms/select.html
+++ b/frontend/template-mixins/partials/forms/select.html
@@ -1,14 +1,14 @@
 <div id="{{id}}-group" class="{{#compound}} form-group-compound{{/compound}}{{#formGroupClassName}} {{formGroupClassName}}{{/formGroupClassName}}{{#error}} govuk-form-group--error{{/error}}">
     {{#isPageHeading}}<h1 class="govuk-label-wrapper">{{/isPageHeading}}<label for="{{id}}" class="{{labelClassName}}{{#isPageHeading}}govuk-label--l{{/isPageHeading}}">
         {{{label}}}
-        {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{hint}}</span>{{/hint}}
-        {{#error}}
-          <p class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{error.message}}
-          </p>
-        {{/error}}
     </label>
     {{#isPageHeading}}</h1>{{/isPageHeading}}
+    {{#hint}}<div {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{hint}}</div>{{/hint}}
+    {{#error}}
+      <p class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span> {{error.message}}
+      </p>
+     {{/error}}
     <select id="{{id}}" class="govuk-select{{#className}} {{className}}{{/className}}{{#error}} govuk-select--error{{/error}}" name="{{id}}" aria-required="{{required}}">
     {{#options}}
         <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>


### PR DESCRIPTION
## What?
- Fixed typo causing spacing issues between label hit and error message on select fields found when updating nrm to latest hof version as part of [HOFF-648](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-648)

## Why?
- Hint and error message were incorrectly in select label tag causing spacing issues -https://design-system.service.gov.uk/components/select/ 
 
## How?
- Moved hint and error message out of select label tag in frontend/template-mixins/partials/forms/select.html

## Testing?
- Tested on other services
## Screenshots (optional)
### Govuk Design system example:
<img width="811" alt="Screenshot 2024-05-22 at 12 53 55" src="https://github.com/UKHomeOfficeForms/hof/assets/43888758/d0065408-9732-49ed-8dc6-a099485344fb">

### Current design with typo in service:
<img width="932" alt="Screenshot 2024-05-22 at 12 05 03" src="https://github.com/UKHomeOfficeForms/hof/assets/43888758/1d2619a3-02bd-4e3c-8b32-09764ae44b86">

### Fix tested in service:
<img width="1026" alt="Screenshot 2024-05-22 at 12 21 35" src="https://github.com/UKHomeOfficeForms/hof/assets/43888758/5066e7da-af6f-49b6-9372-7feda1821fec">

## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant) - not applicable
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging