### PR TITLE
HOFF-869 -Refactor notify component to enable email attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-04-15, Version 22.5.0 (Stable), @shamiluwais
+### Changed
+- Refactors notify component to enable email attachments
+
 ## 2025-04-15, Version 22.4.0 (Stable), @Rhodine-orleans-lindsay
 ### Changed
 - Amends page title format to follow the govuk design system so that the service name is now included in the the title by setting the `header` or `serviceName` in journey.json.

--- a/components/notify/index.js
+++ b/components/notify/index.js
@@ -38,11 +38,13 @@ module.exports = config => {
           if (typeof settings.recipient !== 'string' || !settings.recipient.includes('@')) {
             throw new Error('hof-behaviour-emailer: invalid recipient');
           }
-
           if (typeof config.subject === 'function') {
             settings.subject = config.subject(req.sessionModel.toJSON(), req.translate);
           } else {
             settings.subject = config.subject;
+          }
+          if (config.attachment && config.attachment !== undefined) {
+            settings.attachment = config.attachment(req.sessionModel.toJSON(), req.translate);
           }
 
           return settings;

--- a/components/notify/notify.js
+++ b/components/notify/notify.js
@@ -1,24 +1,50 @@
 'use strict';
+
 const NotifyClient = require('notifications-node-client').NotifyClient;
 const { v4: uuidv4 } = require('uuid');
+const config = require('../../config/hof-defaults');
+const logger = require('../../lib/logger');
 
 module.exports = class Notify {
   constructor(opts) {
     const options = opts || {};
     this.options = options;
+    this.logger = logger(config);
     this.notifyClient =  new NotifyClient(options.notifyApiKey);
     this.notifyTemplate = options.notifyTemplate;
   }
 
-  send(email) {
+  async sendEmail(templateId, recipient, personalisation) {
     const reference = uuidv4();
 
-    return this.notifyClient.sendEmail(this.notifyTemplate, email.recipient, {
-      personalisation: {
-        'email-subject': email.subject,
-        'email-body': email.body
-      },
-      reference });
+    try {
+      await this.notifyClient.sendEmail(templateId, recipient, {
+        personalisation: personalisation,
+        reference });
+      this.logger.log('info', 'Email sent');
+    } catch (error) {
+      this.logger.log('error', error.response ? error.response.data : error.message);
+      throw new Error(error.response ? error.response.data : error.message);
+    }
+  }
+
+  async send(email) {
+    let personalisation = {
+      'email-subject': email.subject,
+      'email-body': email.body
+    };
+
+    if (email.attachment && email.attachment !== undefined) {
+      personalisation = Object.assign({'email-attachment':
+        this.notifyClient.prepareUpload(email.attachment)}, personalisation);
+    }
+
+    try {
+      await this.sendEmail(this.notifyTemplate, email.recipient, personalisation);
+    } catch (error) {
+      this.logger.log('error', error.response ? error.response.data : error.message);
+      throw new Error(error.response ? error.response.data : error.message);
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "22.4.2",
+  "version": "22.5.0",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
**What**
Refactor notify component to enable email attachments. [HOFF-869](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-869)

**Why**
The notify component in the hof framework is not enabled to send attachments with gov.notify emails, which is a requirement of the ROTM service, please [HOFF-814](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-814).

**How**
Refactor the code to upload an attachment, without affecting other services that using the notify component to send emails.

**Test**
Test on two or more services using the hof notify component in local and branch 

**Screenshots(optional)**

**Anything else(optional)**

**Check list**

- [x]  I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ]  I have written tests (if relevant)
- [x]  I have created a JIRA number for my branch
- [ ]  I have created a JIRA number for my commit
- [x]  I have followed the chris beams method for my commit https://cbea.ms/git-commit/, here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ]  Ensure drone builds are green especially tests
- [ ]  I will squash the commits before merging