### PR TITLE
[HOTFIX]: revert auto-publish actions versions for checkout and setup-node

### DIFF
--- a/.github/workflows/automate-publish.yml
+++ b/.github/workflows/automate-publish.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/heads/master')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2.2.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v1
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## What? 
Revert update to auto-publish actions versions for checkout and setup-node 
## Why? 
Auto publish was failing on merge recent pull request to master see - https://github.com/UKHomeOfficeForms/hof/actions/runs/12694354153
## How? 
- change actions/checkout from v4 to v2.2.0
- change actions/setup-node from v4 to v1
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant) - N/A
- [ ] I have created a JIRA number for my branch - N/A (hot fix)
- [ ] I have created a JIRA number for my commit -N/A (hot fix)
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
