### PR TITLE
HOFF-1204: Allow Service unavailable text to use html tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-05-29, Version 22.7.2 (Stable), @Rhodine-orleans-lindsay
+### Fixed
+- Service unavailable text can now use html
+
 ## 2025-05-28, Version 22.7.0 (Stable), @Rhodine-orleans-lindsay @sulthan-ahmed
 ### Added
 - 'Service Unavailable' functionality added which allows for services to redirect to a 'Service Unavailable' page when there is a need to pause a service for things like maintenance:

--- a/frontend/template-partials/views/service-unavailable.html
+++ b/frontend/template-partials/views/service-unavailable.html
@@ -1,13 +1,13 @@
 {{<error}}
   {{$content}}
    <h1 class="govuk-heading-l">{{title}}</h1>
-   <p class="govuk-body">{{message}}</p>
-   <p class="govuk-body">{{answers-saved}}</p>
+   <p class="govuk-body">{{{message}}}</p>
+   <p class="govuk-body">{{{answers-saved}}}</p>
    {{#contact}}
-   <p class="govuk-body">{{contact}}</p>
+   <p class="govuk-body">{{{contact}}}</p>
    {{/contact}}
    {{#alternative}}
-   <p class="govuk-body">{{alternative}}</p>
+   <p class="govuk-body">{{{alternative}}}</p>
    {{/alternative}}
   {{/content}}
 {{/error}}


### PR DESCRIPTION
## What? 
Allow Service unavailable text to use html - [HOFF-1204](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1204)
## Why? 
So that elements like links can be included in text
## How? 
Amended the service-unavailble html
## Testing?
Tested in sandbox. Tests passing locally
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
