### PR TITLE
HOFF-113: removing reference to the hof-generator in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ hof-build watch --env .envdev
 
 ## Configuration
 
-The default settings will match those for an app generated using [`hof-generator`](https://npmjs.com/hof-generator).
-
 If a `hof.settings.json` file is found in the application root, then the `build` section of the settings file will be used to override [the default configuration](./defaults.js).
 
 Alternatively you can define a path to a local config file by passing a `--config` option


### PR DESCRIPTION
## What? 

Removing reference to the hof-generator in the readme configuration section

## Why? 

The hof-generator is deprecated and the preferred approach is to now use the [hof-skeleton](https://github.com/UKHomeOfficeForms/hof-skeleton) instead.

## How? 

Removed line in readme reference configuration matching the hof generator

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [ ] I will squash the commits before merging
