### PR TITLE
HOFF-1209 - Update the cookies page to include GA container id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-07-16, Version 22.8.3 (Stable), @vivekkumar-ho
+### Changed
+- Updated the cookies page to include the GA container ID, which corresponds to the Measurement ID.
+
 ## 2025-07-04, Version 22.8.1 (Stable), @gregaustinHO
 ### Added
 - Add support for source maps while debugging

--- a/frontend/template-partials/translations/src/en/cookies.json
+++ b/frontend/template-partials/translations/src/en/cookies.json
@@ -61,6 +61,8 @@
   },
   "no-identify": "No personal details are stored with this information, so you can’t be identified.",
   "analytics-table": {
+    "containerIdExpires": "2 years",
+    "containerIdPurpose": "Used to persist session state",
     "headers": [
       "Name",
       "Purpose",

--- a/frontend/template-partials/views/cookies.html
+++ b/frontend/template-partials/views/cookies.html
@@ -66,7 +66,7 @@
                 {{/google-analytics-list}}
                 <p>{{no-identify}}</p>
                 {{#analytics-table}}
-                  {{> partials-table}}
+                  {{> partials-analytics-table}}
                 {{/analytics-table}}
                 {{#indent-ga}}
                   {{> partials-panel-indent}}

--- a/frontend/template-partials/views/partials/analytics-table.html
+++ b/frontend/template-partials/views/partials/analytics-table.html
@@ -1,0 +1,25 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      {{#headers}}
+        <th scope="col" class="govuk-table__header app-custom-class">{{.}}</th>
+      {{/headers}}
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body"> 
+    {{#rows}}
+      <tr class="govuk-table__row">
+        {{#.}}
+          <td  class="govuk-table__cell">{{.}}</td>
+        {{/.}}
+      </tr>
+    {{/rows}}
+      <tr class="govuk-table__row">
+        {{#gaContainerId}}
+          <td>_ga_{{gaContainerId}}</td>
+          <td>{{containerIdPurpose}}</td>
+          <td>{{containerIdExpires}}</td>
+        {{/gaContainerId}}
+      </tr>
+  </tbody>
+</table>

--- a/index.js
+++ b/index.js
@@ -162,6 +162,7 @@ function bootstrap(options) {
     res.locals.exitFormContent = config.exitFormContent;
     res.locals.saveExitFormContent = config.saveExitFormContent;
     res.locals.serviceUnavailable = config.serviceUnavailable;
+    res.locals.gaContainerId = config.ga4TagId;
     next();
   });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "22.8.1",
+  "version": "22.8.2",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",


### PR DESCRIPTION
## What? 
[HOFF-1209](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1209) - Update cookie page to include the container id
## Why? 
- Improve transparency with users about how cookies and data collection works 
- Ensure we are aligned with best practices when using GA and consent mode
## How? 
- Updated the analytics table on the cookie page to include the container id, which corresponds to the measurement id
## Testing?
## Screenshots (optional)

Tested with sandbox (with an example measurement id)

<img width="838" height="913" alt="Screenshot 2025-07-16 at 11 19 09" src="https://github.com/user-attachments/assets/5c6f5a82-7d23-4648-ae3a-f8d84b663260" />


## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
