### PR TITLE
NRM-458 Error not being handled

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -166,7 +166,7 @@ module.exports = class Model extends EventEmitter {
       if (typeof callback === 'function') {
         callback(error);
       }
-      return error;
+      throw error;
     }
   }
 

--- a/test/model/index.spec.js
+++ b/test/model/index.spec.js
@@ -3,7 +3,6 @@
 
 const url = require('url');
 const Model = require('../../model');
-const axios = require('axios');
 
 describe('Model', () => {
   let model;
@@ -150,7 +149,7 @@ describe('Model', () => {
       model._request.resolves(Promise.resolve(fail));
       try {
         await model.request(settings, bodyData, sandbox());
-      } catch(e) {
+      } catch(err) {
         model._request.should.have.been.calledOnce;
         const options = model._request.args[0][0];
         options.method.should.equal('POST');
@@ -159,11 +158,11 @@ describe('Model', () => {
       }
     });
 
-    it('can parse failiure when no data or callback given', async () => {
+    it('can parse failure when no data or callback given', async () => {
       model._request.resolves(Promise.resolve(fail));
       try {
         await model.request(settings, sandbox());
-      } catch(e) {
+      } catch(err) {
         model._request.should.have.been.calledOnce;
         const options = model._request.args[0][0];
         options.method.should.equal('POST');
@@ -223,15 +222,16 @@ describe('Model', () => {
     });
 
     it('sends an http PUT request if method option is "PUT"', async () => {
-      sinon.stub(axios, 'post').resolves(Promise.resolve(success));
+      model._request.resolves(Promise.resolve(success));
       try {
         await model.save({ method: 'PUT' }, sandbox());
-      } catch (e) {
         model._request.should.have.been.calledOnce;
         const options = model._request.args[0][0];
         options.method.should.equal('PUT');
         options.url.should.equal('http://example.com:3002/foo/bar');
         options.data.should.equal('{"name":"Test name"}');
+      } catch (e) {
+        e.should.be.undefined;
       }
     });
 
@@ -556,14 +556,12 @@ describe('Model', () => {
       });
     });
 
-    it('rejects with error on failure1', async () => {
+    it('rejects with error on failure', async () => {
       model._request.resolves(Promise.resolve(fail));
       try {
-        await model.save(err => {
-          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-        });
-      // eslint-disable-next-line no-empty
-      } catch(e) {
+        await model.save();
+      } catch(err) {
+        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
       }
     });
   });
@@ -662,12 +660,10 @@ describe('Model', () => {
       model._request.resolves(Promise.resolve(fail));
       sinon.stub(model, 'parse');
       try {
-        await model.fetch(err => {
-          model.parse.should.not.have.been.called;
-          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-        });
-      // eslint-disable-next-line no-empty
-      } catch(e) {
+        await model.fetch();
+      } catch(err) {
+        model.parse.should.not.have.been.called;
+        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
       }
     });
 
@@ -877,11 +873,9 @@ describe('Model', () => {
     it('rejects with error on failure', () => {
       model._request.resolves(Promise.resolve(fail));
       try {
-        model.fetch(err => {
-          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-        });
-      // eslint-disable-next-line no-empty
-      } catch(e) {
+        model.fetch();
+      } catch(err) {
+        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
       }
     });
   });
@@ -980,12 +974,10 @@ describe('Model', () => {
       model._request.resolves(Promise.resolve(fail));
       sinon.stub(model, 'parse');
       try {
-        await model.delete(err => {
-          model.parse.should.not.have.been.called;
-          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-        });
-      // eslint-disable-next-line no-empty
-      } catch(e) {
+        await model.delete();
+      } catch(err) {
+        model.parse.should.not.have.been.called;
+        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
       }
     });
 
@@ -1012,12 +1004,14 @@ describe('Model', () => {
     });
 
     it('passes options to url method if provided', async () => {
+      model._request.resolves(Promise.resolve(success));
       model.url = sinon.stub().returns('http://example.com/');
       try {
         await model.delete({ url: 'foo' }, callback);
-      } catch (e) {
         model.url.should.have.been.calledOnce;
         model.url.should.have.been.calledWithExactly({ url: 'foo' });
+      } catch (e) {
+        e.should.be.undefined;
       }
     });
 
@@ -1188,14 +1182,12 @@ describe('Model', () => {
       });
     });
 
-    it('rejects with error on failure3', async () => {
+    it('rejects with error on failure', async () => {
       model._request.resolves(Promise.resolve(fail));
       try {
-        await model.delete(err => {
-          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-        });
-      // eslint-disable-next-line no-empty
-      } catch(e) {
+        await model.delete();
+      } catch(err) {
+        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
       }
     });
   });

--- a/test/model/index.spec.js
+++ b/test/model/index.spec.js
@@ -247,18 +247,14 @@ describe('Model', () => {
 
     it('calls callback with an error if API response returns an error code', async () => {
       model._request.resolves(Promise.resolve(fail));
-      const savePromise = new Promise((resolve, reject) => {
-        model.save(sandbox((err, data) => {
+      try {
+        await model.save(sandbox((err, data) => {
           if (err) {
             reject(err);
           } else {
             resolve(data);
           }
         }));
-      });
-
-      try {
-        await savePromise;
       } catch (e) {
         e.should.eql({ status: 500, message: 'error', headers: { error: 'fail' } });
       }
@@ -266,33 +262,26 @@ describe('Model', () => {
 
     it('calls callback with json data if response has success code', async () => {
       model._request.resolves(Promise.resolve(success));
-      const savePromise = new Promise((resolve, reject) => {
-        model.save(sandbox((err, data) => {
+      const data = await model.save(sandbox((err, data) => {
           if (err) {
             reject(err);
           } else {
             resolve(data);
           }
         }));
-      });
-      const data = await savePromise;
       data.should.eql({ message: 'success' });
     });
 
     it('passes returned data through parse method on success', async () => {
       sinon.stub(model, 'parse').returns({ parsed: 'message' });
       model._request.resolves(Promise.resolve(success));
-      const savePromise = new Promise((resolve, reject) => {
-        model.save(sandbox((err, data) => {
+      const data = await model.save(sandbox((err, data) => {
           if (err) {
             reject(err);
           } else {
             resolve(data);
           }
         }));
-      });
-
-      const data = await savePromise;
       model.parse.should.have.been.calledOnce;
       model.parse.should.have.been.calledWithExactly({ message: 'success' });
       data.should.eql({ parsed: 'message' });
@@ -301,18 +290,14 @@ describe('Model', () => {
     it('does not parse response on error', async () => {
       model._request.resolves(Promise.resolve(fail));
       sinon.stub(model, 'parse');
-      const savePromise = new Promise((resolve, reject) => {
-        model.save(sandbox((err, data) => {
+      try {
+        await model.save(sandbox((err, data) => {
           if (err) {
             reject(err);
           } else {
             resolve(data);
           }
         }));
-      });
-
-      try {
-        await savePromise;
       } catch (e) {
         model.parse.should.not.have.been.called;
         e.should.eql({ status: 500, message: 'error', headers: { error: 'fail' } });
@@ -322,18 +307,14 @@ describe('Model', () => {
     it('calls parseError on error to extract error status from response', async () => {
       model._request.resolves(Promise.resolve(fail));
       sinon.stub(model, 'parseError').returns({ error: 'parsed' });
-      const savePromise = new Promise((resolve, reject) => {
-        model.save(sandbox((err, data) => {
+      try {
+        await model.save(sandbox((err, data) => {
           if (err) {
             reject(err);
           } else {
             resolve(data);
           }
         }));
-      });
-
-      try {
-        await savePromise;
       } catch (err) {
         model.parseError.should.have.been.calledOnce;
         model.parseError.should.have.been.calledWithExactly(500, { message: 'error' });
@@ -343,19 +324,14 @@ describe('Model', () => {
 
     it('calls callback with error if response is not valid json', async () => {
       model._request.resolves(Promise.resolve(invalid));
-
-      const savePromise = new Promise((resolve, reject) => {
-        model.save((err, data) => {
+      try {
+        await model.save((err, data) => {
           if (err) {
             reject(err);
           } else {
             resolve(data);
           }
         });
-      });
-
-      try {
-        await savePromise;
       } catch (err) {
         err.should.be.an.instanceOf(Error);
         err.status.should.equal(200);
@@ -604,18 +580,14 @@ describe('Model', () => {
 
     it('calls callback with an error if model._request throws error event', async () => {
       model._request.resolves(Promise.reject(error));
-      const fetchPromise = new Promise((resolve, reject) => {
-        model.fetch(sandbox((err, data) => {
+      try {
+        await model.fetch(sandbox((err, data) => {
           if (err) {
             reject(err);
           } else {
             resolve(data);
           }
         }));
-      });
-
-      try {
-        await fetchPromise;
       } catch (e) {
         e.should.eql(error);
       }
@@ -623,17 +595,7 @@ describe('Model', () => {
 
     it('calls callback with json data if response has success code', async () => {
       model._request.resolves(Promise.resolve(success));
-      const fetchPromise = new Promise((resolve, reject) => {
-        model.fetch((err, data) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(data);
-          }
-        });
-      });
-
-      const data = await fetchPromise;
+      const data = await model.fetch();
       data.should.eql({ message: 'success' });
     });
 

--- a/test/model/index.spec.js
+++ b/test/model/index.spec.js
@@ -146,24 +146,30 @@ describe('Model', () => {
       expect(options.data).to.not.be.ok;
     });
 
-    it('can parse failiure when no callback given', async () => {
+    it('can parse failure when no callback given', async () => {
       model._request.resolves(Promise.resolve(fail));
-      await model.request(settings, bodyData, sandbox());
-      model._request.should.have.been.calledOnce;
-      const options = model._request.args[0][0];
-      options.method.should.equal('POST');
-      options.url.should.equal('http://example.com:3002/foo/bar');
-      options.data.should.equal('{"name":"Test name"}');
+      try {
+        await model.request(settings, bodyData, sandbox());
+      } catch(e) {
+        model._request.should.have.been.calledOnce;
+        const options = model._request.args[0][0];
+        options.method.should.equal('POST');
+        options.url.should.equal('http://example.com:3002/foo/bar');
+        options.data.should.equal('{"name":"Test name"}');
+      }
     });
 
     it('can parse failiure when no data or callback given', async () => {
       model._request.resolves(Promise.resolve(fail));
-      await model.request(settings, sandbox());
-      model._request.should.have.been.calledOnce;
-      const options = model._request.args[0][0];
-      options.method.should.equal('POST');
-      options.url.should.equal('http://example.com:3002/foo/bar');
-      expect(options.data).to.not.be.ok;
+      try {
+        await model.request(settings, sandbox());
+      } catch(e) {
+        model._request.should.have.been.calledOnce;
+        const options = model._request.args[0][0];
+        options.method.should.equal('POST');
+        options.url.should.equal('http://example.com:3002/foo/bar');
+        expect(options.data).to.not.be.ok;
+      }
     });
 
     it('sets the timeout from model options', async () => {
@@ -218,12 +224,15 @@ describe('Model', () => {
 
     it('sends an http PUT request if method option is "PUT"', async () => {
       sinon.stub(axios, 'post').resolves(Promise.resolve(success));
-      await model.save({ method: 'PUT' }, sandbox());
-      model._request.should.have.been.calledOnce;
-      const options = model._request.args[0][0];
-      options.method.should.equal('PUT');
-      options.url.should.equal('http://example.com:3002/foo/bar');
-      options.data.should.equal('{"name":"Test name"}');
+      try {
+        await model.save({ method: 'PUT' }, sandbox());
+      } catch (e) {
+        model._request.should.have.been.calledOnce;
+        const options = model._request.args[0][0];
+        options.method.should.equal('PUT');
+        options.url.should.equal('http://example.com:3002/foo/bar');
+        options.data.should.equal('{"name":"Test name"}');
+      }
     });
 
     it('adds content type and length headers to request', async () => {
@@ -547,11 +556,15 @@ describe('Model', () => {
       });
     });
 
-    it('rejects with error on failure', async () => {
+    it('rejects with error on failure1', async () => {
       model._request.resolves(Promise.resolve(fail));
-      await model.save(err => {
-        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-      });
+      try {
+        await model.save(err => {
+          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
+        });
+      // eslint-disable-next-line no-empty
+      } catch(e) {
+      }
     });
   });
 
@@ -648,10 +661,14 @@ describe('Model', () => {
     it('does not parse response on error', async () => {
       model._request.resolves(Promise.resolve(fail));
       sinon.stub(model, 'parse');
-      await model.fetch(err => {
-        model.parse.should.not.have.been.called;
-        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-      });
+      try {
+        await model.fetch(err => {
+          model.parse.should.not.have.been.called;
+          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
+        });
+      // eslint-disable-next-line no-empty
+      } catch(e) {
+      }
     });
 
     it('calls callback with error if response is not valid json', async () => {
@@ -859,9 +876,13 @@ describe('Model', () => {
 
     it('rejects with error on failure', () => {
       model._request.resolves(Promise.resolve(fail));
-      return model.fetch(err => {
-        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-      });
+      try {
+        model.fetch(err => {
+          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
+        });
+      // eslint-disable-next-line no-empty
+      } catch(e) {
+      }
     });
   });
 
@@ -958,10 +979,14 @@ describe('Model', () => {
     it('does not parse response on error', async () => {
       model._request.resolves(Promise.resolve(fail));
       sinon.stub(model, 'parse');
-      await model.delete(err => {
-        model.parse.should.not.have.been.called;
-        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-      });
+      try {
+        await model.delete(err => {
+          model.parse.should.not.have.been.called;
+          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
+        });
+      // eslint-disable-next-line no-empty
+      } catch(e) {
+      }
     });
 
     it('calls callback with error if response is not valid json', async () => {
@@ -988,9 +1013,12 @@ describe('Model', () => {
 
     it('passes options to url method if provided', async () => {
       model.url = sinon.stub().returns('http://example.com/');
-      await model.delete({ url: 'foo' }, callback);
-      model.url.should.have.been.calledOnce;
-      model.url.should.have.been.calledWithExactly({ url: 'foo' });
+      try {
+        await model.delete({ url: 'foo' }, callback);
+      } catch (e) {
+        model.url.should.have.been.calledOnce;
+        model.url.should.have.been.calledWithExactly({ url: 'foo' });
+      }
     });
 
     it('can handle a parsed URL object', async () => {
@@ -1071,9 +1099,13 @@ describe('Model', () => {
     it('emits a "sync" event', async () => {
       const sync = sinon.stub();
       model.on('sync', sync);
-      await model.delete(() => { });
-      sync.should.have.been.calledOnce;
-      sync.should.have.been.calledWith(sinon.match({ method: 'DELETE' }));
+
+      try {
+        await model.delete(() => {});
+      } catch (e) {
+        sync.should.have.been.calledOnce;
+        sync.should.have.been.calledWith(sinon.match({ method: 'DELETE' }));
+      }
     });
 
     it('emits a "fail" event on error', async () => {
@@ -1156,11 +1188,15 @@ describe('Model', () => {
       });
     });
 
-    it('rejects with error on failure', async () => {
+    it('rejects with error on failure3', async () => {
       model._request.resolves(Promise.resolve(fail));
-      await model.delete(err => {
-        err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
-      });
+      try {
+        await model.delete(err => {
+          err.should.eql({ message: 'error', status: 500, headers: { error: 'fail' } });
+        });
+      // eslint-disable-next-line no-empty
+      } catch(e) {
+      }
     });
   });
 


### PR DESCRIPTION
## What?
Bug fix
* When an error occurs during Model request() call it is returned instead of thrown
* This means that may not be handled correctly by the app using HOF
[NRM-458](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-458)

## Why? 
Issue was found where service was expecting the result of request(), but instead received the error object.

## How? 
* Change made to throw error instead of returning it 

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
