### PR TITLE
HOFF-1302: Fix title on Error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-08-28, Version 22.8.5 (Stable), @Rhodine-orleans-lindsay
+### Fixed
+- Fixed bug where if `serviceName` had not been set in journey.json, the title tab on error pages did not default to the `header` in journey.json.
+
 ## 2025-07-24, Version 22.8.4 (Stable), @vivekkumar-ho
 ### Security
 - Upgraded axios version to address a security vulnerability

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -13,13 +13,24 @@ const getContent = (err, translate) => {
   // Helper to safely call translate if it's a function
   const t = key => (typeof translate === 'function' ? translate(key) : undefined);
 
+  // Check whether a service name has been set in the journey.json file
+  const getServiceName = () => {
+    const serviceName = t('journey.serviceName');
+    const header = t('journey.header');
+
+    // Return serviceName if it's translated, otherwise fallback to journey header
+    return serviceName && serviceName !== 'journey.serviceName' ? serviceName : header;
+  };
+
+  const serviceName = getServiceName();
+
   if (err.code === 'SESSION_TIMEOUT') {
     err.status = 401;
     err.template = 'session-timeout';
-    err.serviceName = t('journey.serviceName') || t('journey.header');
+    err.serviceName = serviceName;
     err.title = t('errors.session.title');
     err.message = t('errors.session.message');
-    content.serviceName = t('journey.serviceName') || t('journey.header');
+    content.serviceName = serviceName;
     content.title = t('errors.session.title');
     content.message = t('errors.session.message');
   }
@@ -27,7 +38,7 @@ const getContent = (err, translate) => {
   if (err.code === 'NO_COOKIES') {
     err.status = 403;
     err.template = 'cookie-error';
-    content.serviceName = t('journey.serviceName') || t('journey.header');
+    content.serviceName = serviceName;
     content.title = t('errors.cookies-required.title');
     content.message = t('errors.cookies-required.message');
   }
@@ -35,14 +46,14 @@ const getContent = (err, translate) => {
   if (err.code === 'DDOS_RATE_LIMIT') {
     err.status = 429;
     err.template = 'rate-limit-error';
-    err.serviceName = t('journey.serviceName') || t('journey.header');
+    err.serviceName = serviceName;
     err.title = t('errors.ddos-rate-limit.title');
     err.message = t('errors.ddos-rate-limit.message');
     err.preTimeToWait = t('errors.ddos-rate-limit.pre-time-to-wait');
     err.timeToWait = rateLimitsConfig.rateLimits.requests.windowSizeInMinutes;
     err.postTimeToWait = t('errors.ddos-rate-limit.post-time-to-wait');
     content.title = t('errors.ddos-rate-limit.title');
-    content.serviceName = t('journey.serviceName') || t('journey.header');
+    content.serviceName = serviceName;
     content.message = t('errors.ddos-rate-limit.message');
     content.preTimeToWait = t('errors.ddos-rate-limit.pre-time-to-wait');
     content.timeToWait = rateLimitsConfig.rateLimits.requests.windowSizeInMinutes;
@@ -52,13 +63,13 @@ const getContent = (err, translate) => {
   if (err.code === 'SUBMISSION_RATE_LIMIT') {
     err.status = 429;
     err.template = 'rate-limit-error';
-    err.serviceName = t('journey.serviceName') || t('journey.header');
+    err.serviceName = serviceName;
     err.title = t('errors.submission-rate-limit.title');
     err.message = t('errors.submission-rate-limit.message');
     err.preTimeToWait = t('errors.submission-rate-limit.pre-time-to-wait');
     err.timeToWait = rateLimitsConfig.rateLimits.submissions.windowSizeInMinutes;
     err.postTimeToWait = t('errors.submission-rate-limit.post-time-to-wait');
-    content.serviceName = t('journey.serviceName') || t('journey.header');
+    content.serviceName = serviceName;
     content.title = t('errors.submission-rate-limit.title');
     content.message = t('errors.submission-rate-limit.message');
     content.preTimeToWait = t('errors.submission-rate-limit.pre-time-to-wait');

--- a/middleware/service-unavailable.js
+++ b/middleware/service-unavailable.js
@@ -9,9 +9,12 @@ const getTranslations = translate => {
   };
 
   if (translate) {
+    // set const for checking whether a service name has been set in the journey.json file
+    const isServiceNameSet = translate('journey.serviceName') !== 'journey.serviceName';
+
     const contact = translate('errors.service-unavailable.contact');
     const alternative = translate('errors.service-unavailable.alternative');
-    translations.serviceName = translate('journey.serviceName') || translate('journey.header');
+    translations.serviceName = isServiceNameSet ? translate('journey.serviceName') : translate('journey.header');
     translations.title = translate('errors.service-unavailable.title');
     translations.message = translate('errors.service-unavailable.message');
     translations['answers-saved'] = translate('errors.service-unavailable.answers-saved');


### PR DESCRIPTION
## What? 
[HOFF-1302](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1302) - Fix title on Error pages
## Why? 
 If a service does not have a 'serviceName' set in their journey.json file, the title tab on error pages should default to the 'header' set in the journey.json as is the case with question pages. However on error pages, the title tab show the words 'journey.serviceName' instead.

## How? 
- added conditional to middleware/errors and middleware/service-unavailable to check whether journey.serviceName has been set in service's journey.json and if not default to journey.header.
- update changelog

## Testing?
## Screenshots (optional)
### Before Fix

<img width="1078" height="762" alt="before title fix" src="https://github.com/user-attachments/assets/3659b54e-263d-4ffb-a76f-434b8fc49452" />


### After Fix

<img width="1021" height="763" alt="after title fix" src="https://github.com/user-attachments/assets/8fdeec5a-f587-45de-a74c-d436aeb3a895" />

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
