### PR TITLE
HOFF-1265: Back button leads to session timeout screen missing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2025-09-09, Version 22.9.0 (Stable), @Rhodine-orleans-lindsay
+### Fixed
+- Fixed bug where if text on session-timeout page was not being populated when the browser back button is used.
+### Changed
+- Session timeout page is now only available when there is a 'SESSION_TIMEOUT' error. If there is no such error and user navigates to '/session-timeout, the 'Page not found' error is shown.
+  - 👊 Impact : '/session-timeout' step can be removed from the steps array if it has been set in the project's apps/*/index.js file. This routing is now handled in the hof framework.
+### Security
+- Updates minor dependencies in sandbox
+
 ## 2025-08-28, Version 22.8.5 (Stable), @Rhodine-orleans-lindsay
 ### Fixed
 - Fixed bug where if `serviceName` had not been set in journey.json, the title tab on error pages did not default to the `header` in journey.json.

--- a/index.js
+++ b/index.js
@@ -249,6 +249,30 @@ function bootstrap(options) {
       return next();
     });
   }
+
+  /**
+   * Handles requests to the session timeout page.
+   * - If the user has a session cookie but their session is missing or inactive,
+   *   this triggers a session timeout error handled by error middleware.
+   * - Otherwise, responds with a 404 "Page Not Found" error.
+   * This route ensures the timeout page only appears after an actual session expiry.
+  */
+  app.get('/session-timeout', (req, res, next) => {
+    if ((req.cookies['hof-wizard-sc']) && (!req.session || req.session.exists !== true)) {
+      const err = new Error('Session expired');
+      err.code = 'SESSION_TIMEOUT';
+      return next(err);
+    }
+    const err = new Error('Not Found');
+    err.status = 404;
+    const locals = Object.assign({}, req.translate('errors'));
+    if (locals && locals['404']) {
+      return res.status(404).render('404', locals['404']);
+    }
+    // Fallback: render a basic 404 page if translation is missing
+    return res.status(404).send('Page Not Found');
+  });
+
   if (config.getAccessibility === true) {
     deprecate(
       '`getAccessibility` option is deprecated and may be removed in future versions.',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hof",
   "description": "A bootstrap for HOF projects",
-  "version": "22.8.5",
+  "version": "22.9.0",
   "license": "MIT",
   "main": "index.js",
   "author": "HomeOffice",
@@ -27,7 +27,7 @@
     "test:lint": "eslint . --config ./node_modules/eslint-config-hof/default.js",
     "test:functional": "funkie mocha ./test/functional-tests --timeout 20000 --exit",
     "test:client": "karma start test/frontend/toolkit/karma.conf.js",
-    "test:jest": "jest test/frontend/jest test/utilities/helpers/jest",
+    "test:jest": "jest test/frontend/jest test/integration/index test/utilities/helpers/jest",
     "test:acceptance": "TAGS=\"${TAGS:=@feature}\" yarn run test:cucumber",
     "test:acceptance_browser": "ACCEPTANCE_WITH_BROWSER=true TAGS=\"${TAGS:=@feature}\" yarn run test:cucumber",
     "test:cucumber": "cucumber-js -f @cucumber/pretty-formatter \"sandbox/test/_features/**/*.feature\" --require sandbox/test/_features/test.setup.js --require \"sandbox/test/_features/step_definitions/**/*.js\" --tags $TAGS",

--- a/sandbox/apps/sandbox/index.js
+++ b/sandbox/apps/sandbox/index.js
@@ -92,7 +92,6 @@ module.exports = {
       ],
       next: '/confirm'
     },
-    '/session-timeout': {},
     '/exit': {},
     '/save-and-exit': {}
   }

--- a/sandbox/yarn.lock
+++ b/sandbox/yarn.lock
@@ -130,12 +130,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-jquery@>=1.11:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
-
-jquery@^3.7.1:
+jquery@>=1.11, jquery@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -1,0 +1,86 @@
+const request = require('supertest');
+const express = require('express');
+
+describe('bootstrap /session-timeout route', () => {
+  let app;
+  let locals;
+
+  beforeEach(() => {
+    app = express();
+    app.use(require('cookie-parser')());
+
+    // Mock a session
+    app.use((req, res, next) => {
+      if (typeof req.headers['x-session-exists'] !== 'undefined') {
+        req.session = { exists: req.headers['x-session-exists'] === 'true' };
+      }
+      next();
+    });
+
+    // Mock translations
+    app.use((req, res, next) => {
+      req.translate = () => ({ 404: { message: 'Page does not exist' } });
+      next();
+    });
+
+    // The /session-timeout routing
+    app.get('/session-timeout', (req, res, next) => {
+      if ((req.cookies['hof-wizard-sc']) && (!req.session || req.session.exists !== true)) {
+        const err = new Error('Session expired');
+        err.code = 'SESSION_TIMEOUT';
+        return next(err);
+      }
+      const err = new Error('Not Found');
+      err.status = 404;
+      locals = Object.assign({}, req.translate('errors'));
+      if (locals && locals['404']) {
+        return res.status(404).send(locals['404'].message);
+      }
+      return res.status(404).send('Page Not Found');
+    });
+
+    // Mock error middleware
+    app.use((err, req, res, next) => {
+      if (err.code === 'SESSION_TIMEOUT') {
+        return res.status(401).send('Session Timeout');
+      }
+      if (err.status === 404) {
+        return res.status(404).send('Page Not Found');
+      }
+      return next();
+    });
+  });
+
+  it('responds with 401 Session Timeout if session cookie present but session missing', async () => {
+    const response = await request(app)
+      .get('/session-timeout')
+      .set('Cookie', 'hof-wizard-sc=1');
+    expect(response.status).toBe(401);
+    expect(response.text).toContain('Session Timeout');
+  });
+
+  it('responds with 401 Session Timeout if session cookie present but session inactive', async () => {
+    const response = await request(app)
+      .get('/session-timeout')
+      .set('Cookie', 'hof-wizard-sc=1')
+      .set('x-session-exists', 'false');
+    expect(response.status).toBe(401);
+    expect(response.text).toContain('Session Timeout');
+  });
+
+  it('responds with 404 Page Not Found if no session cookie', async () => {
+    const response = await request(app)
+      .get('/session-timeout');
+    expect(response.status).toBe(404);
+    expect(response.text).toContain('Page does not exist');
+  });
+
+  it('responds with 404 Page Not Found if session cookie present and session active', async () => {
+    const response = await request(app)
+      .get('/session-timeout')
+      .set('Cookie', 'hof-wizard-sc=1')
+      .set('x-session-exists', 'true');
+    expect(response.status).toBe(404);
+    expect(response.text).toContain('Page does not exist');
+  });
+});


### PR DESCRIPTION
## What? 
HOFF-1265: Back button leads to session timeout screen missing text - [HOFF-1265](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1265)
## Why? 
- When the session initially times out everything on the page is working as expected, clicking the browser's back button on the initial timeout page redirects to a blank timeout page with no content.The Start Again button on this page is non-functional.
## How? 
- amended index.js to get the session timeout page and show session-timeout content if there is a session timeout error and to show 'page not found' if there is no session timeout error
- removed '/session timeout' step from sandbox's apps/sandbox/index.js as this is now handled in hof/index.js
- updated changelog
## Testing?
- tests passing locally
- beta version tested on ARE, VIPTT and ASC using hof@22.9.0-fix-timeout-back-button-bug-beta.4
## Screenshots (optional)
### Before fix
https://github.com/user-attachments/assets/3a6ec728-1ed0-4cb3-aec1-9e49cc503b7a

### After fix
https://github.com/user-attachments/assets/a7e01350-b89d-4865-9108-b2c673fc7b88

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
