### PR TITLE
HOFF-2037: Nunjucks Refactoring(Textarea Mixin)

### DIFF
--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -505,7 +505,7 @@ module.exports = function (options) {
           className: 'govuk-input'
         }
       },
-      'inputFile': {
+      inputFile: {
         path: 'partials/forms/input-text-group',
         renderWith: inputText,
         options: {
@@ -701,32 +701,36 @@ module.exports = function (options) {
       // - a string key
       // - a field object (with .key and other props)
       // - undefined (use this as already-populated field)
-      const fields = (this && this.options && this.options.fields) || res.locals.fields || [];
+      const baseCtx = this;
+      const fields = (baseCtx && baseCtx.options && baseCtx.options.fields) || res.locals.fields || [];
 
       if (key && typeof key === 'object') {
         // called with the full field object
         Object.assign(this, key);
       } else if (typeof key === 'string' && key.length) {
         const field = fields.find(f => f.key === key);
-        if (field) {
-          Object.assign(this, field);
-        } else {
+        if (!field) {
           throw new Error('Could not find field: ' + key);
         }
+        key = field;
+      } else {
+        key = baseCtx;
       }
 
-      if (this.disableRender) {
+      const ctx = Object.assign({}, res.locals, baseCtx, key);
+
+      if (ctx.disableRender) {
         return null;
       }
 
-      if (this.html) {
-        return this.html;
+      if (ctx.html) {
+        return ctx.html;
       }
 
-      const mixin = this.mixin || 'inputText';
+      const mixin = key.mixin || 'inputText';
+
       if (mixin && res.locals[mixin] && typeof res.locals[mixin] === 'function') {
-        const ctx = Object.assign({}, res.locals);
-        return res.locals[mixin].call(ctx, this.key || (this && this.key));
+        return res.locals[mixin].call(ctx, ctx.key || (ctx && ctx.key));
       }
       throw new Error('Mixin: "' + mixin + '" not found');
     }

--- a/frontend/template-mixins/partials/forms/textarea-group.html
+++ b/frontend/template-mixins/partials/forms/textarea-group.html
@@ -1,37 +1,75 @@
-{{#isMaxlengthOrMaxword}}<div class="govuk-character-count" data-module="govuk-character-count"
-    {{#maxlength}}data-maxlength="{{maxlength}}" {{/maxlength}} {{#maxword}}data-maxwords="{{maxword}}" {{/maxword}}>
-    {{/isMaxlengthOrMaxword}}
-    <div id="{{id}}-group" class="govuk-form-group {{#formGroupClassName}}{{formGroupClassName}}{{/formGroupClassName}}{{#error}} govuk-form-group--error{{/error}}">
-        {{#isPageHeading}}<h1 class="govuk-label-wrapper">{{/isPageHeading}}
-            <label for="{{id}}"
-                class="{{labelClassName}} {{#isPageHeading}}govuk-label--l{{/isPageHeading}}">
-                {{{label}}}
-            </label>
-        {{#isPageHeading}}</h1>{{/isPageHeading}}
-        {{#hint}}<div {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{{hint}}}</div>{{/hint}}
-        {{#error}}
-        <p id="{{id}}-error" class="govuk-error-message">
-            <span id="{{id}}-error" class="govuk-visually-hidden">Error:</span>{{error.message}}
-        </p>
-        {{/error}}
-        {{#renderChild}}{{/renderChild}}
-        <textarea name="{{id}}" id="{{id}}"
-            class="govuk-textarea {{#isMaxlengthOrMaxword}}govuk-js-character-count{{/isMaxlengthOrMaxword}} {{#className}}{{className}}{{/className}} {{#error}}govuk-input--error{{/error}}"
-            {{#isMaxlengthOrMaxword}}
-            aria-describedby="{{id}}-hint {{id}}-info"
-            {{/isMaxlengthOrMaxword}}
-            {{#attributes}}
-                {{attribute}}="{{value}}"
-            {{/attributes}}
-            {{^error}}{{#hintId}}{{#maxlength}} aria-describedby="{{id}}-maxlength-hint {{hintId}}"{{/maxlength}}{{/hintId}}{{/error}}
-            {{^error}}{{#hintId}}{{^maxlength}} aria-describedby="{{hintId}}"{{/maxlength}}{{/hintId}}{{/error}}
-            {{^error}}{{^hintId}}{{#maxlength}}aria-describedby="{{id}}-maxlength-hint" {{/maxlength}}{{/hintId}}{{/error}}
-            {{#error}} aria-invalid="true" aria-describedby="{{id}}-error" {{/error}}
-            >{{value}}</textarea>
-        {{#isMaxlengthOrMaxword}}
-        <div id="{{id}}-info" class=" govuk-hint govuk-character-count__message">You have {{#maxlength}}{{maxlength}} characters{{/maxlength}}{{#maxword}}{{maxword}}
-            words{{/maxword}} remaining
-        </div>
-        {{/isMaxlengthOrMaxword}}
-    </div>
-{{#isMaxlengthOrMaxword}}</div>{{/isMaxlengthOrMaxword}}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+
+{#-------------------------------------------#}
+{#  Set form group and label classes         #}
+{#-------------------------------------------#}
+{% set formGroupClasses = "" %}
+{% set labelClasses = "" %}
+
+{% set formGroupClasses = formGroupClasses + "form-group-compound " if compound %}
+
+{% set formGroupClasses = formGroupClasses + formGroupClassName if formGroupClassName %}
+
+{% set labelClasses = labelClasses + "govuk-label--l " if isPageHeading %}
+
+{#------------------------------------------#}
+{#  Set hint object if hint exists          #}
+{#------------------------------------------#}
+{% set hintObj = null %}
+{% if hint %}
+  {% set hintObj = {
+    html: hint | safe,
+    classes: "govuk-hint",
+    id: hintId
+  } %}
+{% endif %}
+
+{#------------------------------------------#}
+{#  Set error object if error exists        #}
+{#------------------------------------------#}
+{% set errorObj = null %}
+{% if error %}
+  {% set errorObj = {
+    text: error.message,
+    id: error.id
+  } %}
+{% endif %}
+
+{#----------------------------------------------#}
+{#  Set beforeInput HTML from renderChild()     #}
+{#----------------------------------------------#}
+{% if renderChild is defined %}
+  {% set beforeInputObj = { html: renderChild({}) | safe } %}
+{% else %}
+  {% set beforeInputObj = undefined %}
+{% endif %}
+
+{% set args = {
+  formGroup: {
+      classes: formGroupClasses,
+      beforeInput: beforeInputObj
+  },  
+  name: id,
+  id: id,
+  classes: className,
+  label: {
+      html: label | safe,
+      classes: labelClasses + labelClassName,
+      isPageHeading: isPageHeading,
+      for: id
+  },
+  value: value,
+  hint: hintObj,
+  maxlength: maxlength,
+  maxwords: maxword,
+  errorMessage: errorObj,
+  rows: attributes.rows,
+  attributes: attributes
+} %}
+
+{% if isMaxlengthOrMaxword %}
+  {{govukCharacterCount(args)}}
+{% else %}
+  {{ govukTextarea(args)}}
+{% endif %}

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -1065,29 +1065,33 @@ describe('Template Mixins', () => {
     describe('textarea', () => {
       it('adds a function to res.locals', () => {
         middleware(req, res, next);
-        res.locals.textarea.should.be.a('function');
+        expect(typeof res.locals.textarea).toBe('function');
       });
 
-      it('returns a function', () => {
+      it('returns an object', () => {
         middleware(req, res, next);
-        res.locals.textarea().should.be.a('function');
+        expect(typeof res.locals.textarea()).toBe('object');
       });
 
       it('looks up field label', () => {
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          label: 'fields.field-name.label'
-        }));
+        res.locals.textarea('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            label: 'fields.field-name.label'
+          }));
       });
 
       it('prefixes translation lookup with namespace if provided', () => {
         middleware = mixins({ sharedTranslationsKey: 'name.space' });
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          label: 'name.space.fields.field-name.label'
-        }));
+        res.locals.textarea('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            label: 'name.space.fields.field-name.label'
+          }));
       });
 
       it('should have classes if one or more were specified against the field', () => {
@@ -1097,10 +1101,12 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          className: 'abc def'
-        }));
+        res.locals.textarea('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            className: 'abc def'
+          }));
       });
 
       it('uses maxlength property set at a field level over default option', () => {
@@ -1112,35 +1118,44 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          maxlength: 10
-        }));
+        res.locals.textarea('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            maxlength: 10
+          }));
       });
 
       it('uses locales translation property', () => {
-        req.translate = sinon.stub().withArgs('field-name.label').returns('Field name');
+        req.translate = jest.fn().mockImplementation(key => {
+          if (key === 'field-name.label') return 'Field name';
+          return undefined;
+        });
         res.locals.options.fields = {
           'field-name': {
             label: 'field-name.label'
           }
         };
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          label: 'Field name'
-        }));
+        res.locals.textarea('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            label: 'Field name'
+          }));
       });
 
-      it('sets `labelClassName` to "govuk-label" by default', () => {
+      it('sets `labelClassName` to an empty string by default', () => {
         res.locals.options.fields = {
           'field-name': {}
         };
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          labelClassName: 'govuk-label'
-        }));
+        res.locals.textarea('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            labelClassName: ''
+          }));
       });
 
       it('adds `labelClassName` to existing default classes when set in field options', () => {
@@ -1150,10 +1165,12 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          labelClassName: 'govuk-label visuallyhidden'
-        }));
+        res.locals.textarea('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            labelClassName: 'visuallyhidden'
+          }));
       });
 
       it('adds all classes of `labelClassName` option to existing defaults', () => {
@@ -1163,10 +1180,12 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          labelClassName: 'govuk-label abc def'
-        }));
+        res.locals.textarea('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            labelClassName: 'abc def'
+          }));
       });
 
       it('sets additional element attributes', () => {
@@ -1179,13 +1198,17 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals.textarea().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          attributes: [
-            { attribute: 'spellcheck', value: 'true' },
-            { attribute: 'autocapitalize', value: 'sentences' }
-          ]
-        }));
+        res.locals.textarea('field-name');
+
+        const lastCall = renderSpy.mock.calls.at(-1);
+        const context = lastCall[1];
+
+        expect(context.attributes).toEqual(
+          expect.objectContaining({
+            spellcheck: 'true',
+            autocapitalize: 'sentences'
+          })
+        );
       });
     });
 


### PR DESCRIPTION
## What? 
[HOFF-2037](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2037) - Nunjucks Refactoring (Textarea Mixin)
## Why? 
Part of nunjucks refactoring work.
## How? 
- refactored template mixin to fix bug where fields without specified mixins where inheriting from the last specified mixin on the same page instead of defaulting to inputText
- updated textarea-group.html to use govuk component
- update unit tests related to textarea mixin The following block has been refactored following its nunjucks conversion and is now passing:
  - describe('textarea'
Other blocks in the test suite are testing mixins that have not yet been converted and so will be addressed in future tickets.

## Testing?
- Unit tests related to textarea passing
- tested in hof/sandbox and locally on ETA using beta version - 24.0.0-nunjucks-refactoring-textarea-beta.6 - https://github.com/UKHomeOffice/eta/pull/81
## Screenshots (optional)
## Anything Else? (optional)
Note other unit tests will still fail as those components have not yet been refactored
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests - other unit tests will still fail as those components have not yet been refactored
- [x] I will squash the commits before merging

