### PR TITLE
HOFF-2036: Nunjucks Refactoring: Select Mixin

### DIFF
--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -34,8 +34,19 @@ module.exports = function (options) {
   const compiled = {};
   const templateCache = {};
 
+  function formatToArray(value) {
+    // account for values being an array or a single object
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (value !== undefined && value !== null) {
+      return [value];
+    }
+    return [];
+  }
+
   function maxlength(field) {
-    const validations = field.validate || [];
+    const validations = formatToArray(field.validate);
     const ml = validations.find(validation => validation?.type === 'maxlength' || validation?.type === 'exactlength');
     if (ml) {
       return Array.isArray(ml.arguments) ? ml.arguments[0] : ml.arguments;
@@ -44,7 +55,7 @@ module.exports = function (options) {
   }
 
   function maxword(field) {
-    const validations = field.validate || [];
+    const validations = formatToArray(field.validate);
     const mw = validations.find(validation => validation?.type === 'maxword');
     if (mw) {
       return Array.isArray(mw.arguments) ? mw.arguments[0] : mw.arguments;
@@ -299,10 +310,16 @@ module.exports = function (options) {
       const required = isRequired(field);
       const labelClassName = classNames(field, 'labelClassName');
       const autocomplete = field.autocomplete || extension.autocomplete || 'off';
+      const selectItems = field.options?.map(option => ({
+        value: option.value,
+        text: t(option.label),
+        selected: option.selected
+      }));
       // govUk components set the attribute property as { attribute: value }
       // but in hof, some attributes can be found in the field.validate object as [attribute, { type: attribute, value: value }]
       // and field.attributes object with the format [{ type: attribute, value: value }]
-      const validation = (field.validate || []).reduce((acc, rule) => {
+      const rules = formatToArray(field.validate);
+      const validation = rules.reduce((acc, rule) => {
         // convert required, maxlength, min and max attributes in field.validate object to govuk component compatible format
         if (rule === 'required') {
           acc['aria-required'] = 'true';
@@ -352,6 +369,7 @@ module.exports = function (options) {
         prefix: isPrefixOrSuffix(field.attributes, 'prefix'),
         suffix: isPrefixOrSuffix(field.attributes, 'suffix'),
         isMaxlengthOrMaxword: maxlength(field) || extension.maxlength || maxword(field) || extension.maxword,
+        items: selectItems,
         renderChild: renderChild.bind(this)
       });
     }

--- a/frontend/template-mixins/partials/forms/select.html
+++ b/frontend/template-mixins/partials/forms/select.html
@@ -1,17 +1,63 @@
-<div id="{{id}}-group" class="{{#compound}} form-group-compound{{/compound}}{{#formGroupClassName}} {{formGroupClassName}}{{/formGroupClassName}}{{#error}} govuk-form-group--error{{/error}}">
-    {{#isPageHeading}}<h1 class="govuk-label-wrapper">{{/isPageHeading}}<label for="{{id}}" class="{{labelClassName}} {{#isPageHeading}}govuk-label--l{{/isPageHeading}}">
-        {{{label}}}
-    </label>
-    {{#isPageHeading}}</h1>{{/isPageHeading}}
-    {{#hint}}<div {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{{hint}}}</div>{{/hint}}
-    {{#error}}
-      <p class="govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span> {{error.message}}
-      </p>
-     {{/error}}
-    <select id="{{id}}" class="govuk-select{{#className}} {{className}}{{/className}}{{#error}} govuk-select--error{{/error}}" name="{{id}}" aria-required="{{required}}">
-    {{#options}}
-        <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>
-    {{/options}}
-    </select>
-</div>
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{#-------------------------------------------#}
+{#  Set form group and label classes         #}
+{#-------------------------------------------#}
+{% set formGroupClasses = "" %}
+{% set labelClasses = "" %}
+
+{% set formGroupClasses = formGroupClasses + "form-group-compound " if compound %}
+
+{% set formGroupClasses = formGroupClasses + formGroupClassName if formGroupClassName %}
+
+{% set labelClasses = labelClasses + "govuk-label--l " if isPageHeading %}
+
+{#------------------------------------------#}
+{#  Set hint object if hint exists          #}
+{#------------------------------------------#}
+{% set hintObj = null %}
+{% if hint %}
+  {% set hintObj = {
+    html: hint | safe,
+    classes: "govuk-hint",
+    id: hintId
+  } %}
+{% endif %}
+
+{#------------------------------------------#}
+{#  Set error object if error exists        #}
+{#------------------------------------------#}
+{% set errorObj = null %}
+{% if error %}
+  {% set errorObj = {
+    text: error.message,
+    id: error.id
+  } %}
+{% endif %}
+
+{#----------------------------------------------#}
+{#  Set govukSelect args                         #}
+{#----------------------------------------------#}
+{% set args = {
+  id: id,
+  name: id,
+  value: value,
+  formGroup: {
+    classes: formGroupClasses
+  },
+  label: {
+    html: label | safe,
+    classes: labelClasses + labelClassName,
+    isPageHeading: isPageHeading,
+    for: id
+  },
+  hint: hintObj,
+  errorMessage: errorObj,
+  classes: className,
+  items: items,
+  attributes: {
+    "aria-required": required
+  }
+} %}
+
+{{ govukSelect(args) }}

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -1647,28 +1647,27 @@ describe('Template Mixins', () => {
     });
 
     describe('select', () => {
-      beforeEach(() => {
-      });
-
       it('adds a function to res.locals', () => {
         middleware(req, res, next);
-        res.locals.select.should.be.a('function');
+        expect(typeof res.locals.select).toBe('function');
       });
 
-      it('returns a function', () => {
+      it('returns an object', () => {
         middleware(req, res, next);
-        res.locals.select().should.be.a('function');
+        expect(typeof res.locals.select()).toBe('object');
       });
 
-      it('defaults `labelClassName` to "govuk-label "', () => {
+      it('defaults `labelClassName` to empty string', () => {
         res.locals.options.fields = {
           'field-name': {}
         };
         middleware(req, res, next);
-        res.locals.select().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          labelClassName: 'govuk-label'
-        }));
+        res.locals.select('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            labelClassName: ''
+          }));
       });
 
       it('adds `labelClassName` to the default class when set in field options', () => {
@@ -1678,10 +1677,12 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals.select().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          labelClassName: 'govuk-label visuallyhidden'
-        }));
+        res.locals.select('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            labelClassName: 'visuallyhidden'
+          }));
       });
 
       it('adds all classes of `labelClassName` option', () => {
@@ -1691,73 +1692,72 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals.select().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          labelClassName: 'govuk-label abc def'
-        }));
+        res.locals.select('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            labelClassName: 'abc def'
+          }));
       });
 
       it('includes a hint if it is defined in the locales', () => {
-        req.translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
+        req.translate = jest.fn('field-name.hint').mockReturnValue('Field hint');
         res.locals.options.fields = {
-          'field-name': {
-          }
+          'field-name': {}
         };
         middleware(req, res, next);
-        res.locals.select().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          hint: 'Field hint'
-        }));
+        res.locals.select('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            hint: 'Field hint'
+          })
+        );
       });
 
-      it('includes a hint if it is defined in translation', () => {
-        req.translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
-        res.locals.options.fields = {
-          'field-name': {
-            hint: 'field-name.hint'
-          }
-        };
-        middleware(req, res, next);
-        res.locals.select().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          hint: 'Field hint'
-        }));
-      });
 
       it('does not include a hint if it is not defined in translation', () => {
-        req.translate = sinon.stub().withArgs('field-name.hint').returns(null);
+        req.translate = jest.fn().mockImplementation(key => {
+          if (key === 'field-name.hint') return null;
+          return key;
+        });
         res.locals.options.fields = {
           'field-name': {
             hint: 'field-name.hint'
           }
         };
         middleware(req, res, next);
-        res.locals.select().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          hint: null
-        }));
+        res.locals.select('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            hint: null
+          }));
       });
 
-      it('sets labels to an empty string for translations that are returned as `undefined`', () => {
-        req.translate = sinon.stub().returns(undefined);
+      it('sets labels to an empty string for translations that are returned as undefined', () => {
+        req.translate = jest.fn().mockImplementation(() => { return undefined; });
         res.locals.options.fields = {
           'field-name': {
-            options: [
-              ''
-            ]
+            options: ['']
           }
         };
         middleware(req, res, next);
-        res.locals.select().call(res.locals, 'field-name');
-        render.lastCall.should.have.been.calledWith(sinon.match(function (value) {
-          const obj = value.options[0];
-          return _.isMatch(obj, {
-            label: '',
-            selected: false,
-            toggle: undefined,
-            value: ''
-          });
-        }));
+        res.locals.select('field-name');
+
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            options: [
+              expect.objectContaining({
+                label: '',
+                selected: false,
+                toggle: undefined,
+                value: ''
+              })
+            ]
+          })
+        );
       });
     });
   });


### PR DESCRIPTION
## What? 
[HOFF-2036](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2036) - Nunjucks Refactoring (Select Mixin)
## Why? 
Part of nunjucks refactoring work.
## How? 
- converted select.html into govuk component

- refactored template-mixins.js:
  - updated add items prop to inputText function so it can be accessed by select mixins in line with govuk component structure
  - fixed bug after removing underscore and using native JS .find()  and using .reduce() caused error when field.validate is not an array. Added a helper function to format field.validate to an array before running those methods

- refactored select mixin tests. The following block has been refactored following its nunjucks conversion and is now passing:
  - describe('select'
Other blocks in the test suite are testing mixins that have not yet been converted and so will be addressed in future tickets.

## Testing?
- Unit tests related to select passing
- tested in hof/sandbox and locally on ARE using beta version - 24.0.0-nunjucks-refactoring-select-beta.8 - https://github.com/UKHomeOffice/AppealRightsExhausted/pull/201
## Screenshots (optional)
## Anything Else? (optional)
Note other unit tests will still fail as those components have not yet been refactored
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests - other unit tests will still fail as those components have not yet been refactored
- [x] I will squash the commits before merging


