### PR TITLE
HOFF-2033 and HOFF-2042: Nunjucks Refactoring (Terms and Bullet List …

### DIFF
--- a/frontend/template-partials/translations/src/cy/terms.json
+++ b/frontend/template-partials/translations/src/cy/terms.json
@@ -1,28 +1,28 @@
 {
   "header": "Telerau ac amodau",
-  "how-we-use": "Sut rydym yn defnyddio eich gwybodaeth",
-  "data-link": {
+  "how_we_use": "Sut rydym yn defnyddio eich gwybodaeth",
+  "data_link": {
     "before": "Mae’r data rydych yn ei ddarparu yn cael ei ddefnyddio yn unol â ",
     "href": "https://www.gov.uk/government/organisations/home-office/about/personal-information-charter",
     "link": "siarter gwybodaeth y Swyddfa Gartref",
     "after": ". Mae hyn yn cynnwys gwybodaeth am yr ymgeisydd ac unrhyw berson sy’n noddi eu cais. Y Swyddfa Gartref yw’r rheolydd data, sy’n golygu ei fod yn penderfynu sut y caiff y wybodaeth hon ei defnyddio a’i storio. Bydd y wybodaeth yn cael ei chadw’n gyfrinachol a’i thrin yn unol â Deddf Diogelu Data 1998."
   },
-  "used-for": "Bydd y wybodaeth yn cael ei ddefnyddio i:",
-  "used-for-list": {
+  "used_for": "Bydd y wybodaeth yn cael ei ddefnyddio i:",
+  "used_for_list": {
     "items": [
       "wneud penderfyniad ar gais",
       "atal a chanfod troseddau"
     ]
   },
-  "your-info": "Gall eich gwybodaeth gael ei throsglwyddo i drydydd partïon, adrannau’r llywodraeth, awdurdodau lleol, llywodraethau tramor a chyrff cyhoeddus at ddibenion:",
-  "your-info-list": {
+  "your_info": "Gall eich gwybodaeth gael ei throsglwyddo i drydydd partïon, adrannau’r llywodraeth, awdurdodau lleol, llywodraethau tramor a chyrff cyhoeddus at ddibenion:",
+  "your_info_list": {
     "items": [
       "cadarnhau bod y wybodaeth a roddwyd gennych yn gywir,",
       "atal a chanfod troseddau, gan gynnwys twyll a gwyngalchu arian",
       "caniatáu i drydydd parti, adran o’r llywodraeth, awdurdod lleol neu gorff cyhoeddus gynnal eu hyfforddiant staff"
     ]
   },
-  "info-gathered": "Mae’r Swyddfa Gartref yn cadw’r hawl i gasglu gwybodaeth sy’n ymwneud â defnyddio’r safle. Mae unrhyw wybodaeth a gesglir ar gyfer defnydd mewnol yn bennaf, er enghraifft, i wella gwasanaeth cwsmeriaid.",
+  "info_gathered": "Mae’r Swyddfa Gartref yn cadw’r hawl i gasglu gwybodaeth sy’n ymwneud â defnyddio’r safle. Mae unrhyw wybodaeth a gesglir ar gyfer defnydd mewnol yn bennaf, er enghraifft, i wella gwasanaeth cwsmeriaid.",
   "countries": "Cyfeiriadau at wledydd a chenhedloedd",
-  "countries-text": "Gellir rhestru gwlad neu diriogaeth fel cenedligrwydd neu wlad oherwydd bod ganddi awdurdod i roi pasbort."
+  "countries_text": "Gellir rhestru gwlad neu diriogaeth fel cenedligrwydd neu wlad oherwydd bod ganddi awdurdod i roi pasbort."
 }

--- a/frontend/template-partials/translations/src/en/terms.json
+++ b/frontend/template-partials/translations/src/en/terms.json
@@ -1,28 +1,28 @@
 {
   "header": "Terms and conditions",
-  "how-we-use": "How we use your information",
-  "data-link": {
+  "how_we_use": "How we use your information",
+  "data_link": {
     "before": "The data you provide is used in accordance with the ",
     "href": "https://www.gov.uk/government/organisations/home-office/about/personal-information-charter",
     "link": "Home Office's personal information charter",
     "after": ". This includes information about the applicant and any person sponsoring their application. The Home Office is the data controller, which means that it decides how this information will be used and stored. The information will be held in confidence and handled in accordance with the Data Protection Act 1998."
   },
-  "used-for": "The information will be used to help:",
-  "used-for-list": {
+  "used_for": "The information will be used to help:",
+  "used_for_list": {
     "items": [
       "make a decision on an application",
       "prevent and detect crime"
     ]
   },
-  "your-info": "Your information may be passed on to third parties, government departments, local authorities, foreign governments and public bodies for the purpose of:",
-  "your-info-list": {
+  "your_info": "Your information may be passed on to third parties, government departments, local authorities, foreign governments and public bodies for the purpose of:",
+  "your_info_list": {
     "items": [
       "confirming that the information you have provided is accurate",
       "preventing and detecting crime, including fraud and money laundering",
       "allowing a third party, government department, local authority or public body to carry out their work staff training"
     ]
   },
-  "info-gathered": "The Home Office reserves the right to gather information relating to site usage. Any information gathered is mainly for internal use, for example, to improve customer service.",
+  "info_gathered": "The Home Office reserves the right to gather information relating to site usage. Any information gathered is mainly for internal use, for example, to improve customer service.",
   "countries": "References to countries and nationalities",
-  "countries-text": "A country or territory may be listed as a nationality or country because it has a passport-issuing authority."
+  "countries_text": "A country or territory may be listed as a nationality or country because it has a passport-issuing authority."
 }

--- a/frontend/template-partials/views/partials/bullet-list.html
+++ b/frontend/template-partials/views/partials/bullet-list.html
@@ -1,7 +1,7 @@
 <ul class="govuk-list govuk-list--bullet">
-  {{#items}}
-    <li>
-      {{.}}
-    </li>
-  {{/items}}
+  {% for item in items %}
+  <li>
+    {{ item }}
+  </li>
+{% endfor %}
 </ul>

--- a/frontend/template-partials/views/partials/external-link.html
+++ b/frontend/template-partials/views/partials/external-link.html
@@ -1,1 +1,1 @@
-<p class="govuk-body">{{before}}<a class="govuk-link" href="{{href}}" rel="external">{{link}}</a>{{after}}</p>
+<p class="govuk-body">{{ ctx.before }}<a class="govuk-link" href="{{ ctx.href }}" rel="external">{{ ctx.link }}</a>{{ ctx.after }}</p>

--- a/frontend/template-partials/views/terms.html
+++ b/frontend/template-partials/views/terms.html
@@ -1,26 +1,32 @@
-{{<layout}}
+{% extends "layout.html" %}
 
-  {{$propositionHeader}}{{/propositionHeader}}
+{% block propositionHeader %}{% endblock %}
 
-  {{$header}}
-    {{header}}
-  {{/header}}
+{% block mainContent %}
+  <h2>{{ how_we_use }}</h2>
 
-  {{$content}}
-    <h2>{{how-we-use}}</h2>
-    {{#data-link}}
-      {{> partials-external-link}}
-    {{/data-link}}
-    <p>{{used-for}}</p>
-    {{#used-for-list}}
-      {{> partials-bullet-list}}
-    {{/used-for-list}}
-    <p>{{your-info}}</p>
-    {{#your-info-list}}
-      {{> partials-bullet-list}}
-    {{/your-info-list}}
-    <p>{{info-gathered}}</p>
-    <h2>{{countries}}</h2>
-    <p>{{countries-text}}</p>
-  {{/content}}
-{{/layout}}
+  {% if data_link %}
+    {% set ctx = data_link %}
+    {% include "partials/external-link.html" %}
+  {% endif %}
+
+  <p>{{ used_for }}</p>
+
+  {% if used_for_list %}
+  {% set items = used_for_list.items %}
+  {% include "partials/bullet-list.html" %}
+  {% endif %}
+
+  <p>{{ your_info }}</p>
+
+  {% if your_info_list %}
+    {% set items = your_info_list.items %}
+    {% include "partials/bullet-list.html" %}
+  {% endif %}
+
+  <p>{{ info_gathered }}</p>
+
+  <h2>{{ countries }}</h2>
+
+  <p>{{ countries_text }}</p>
+{% endblock %}


### PR DESCRIPTION
## What? 
- [HOFF-2033](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2033)- Nunjucks Refactoring (Terms)
- [HOFF-2042](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2042) - Nunjucks Refactoring (Bullet list partial)
## Why? 
Part of nunjucks refactoring work.
## How? 
HOFF-2033: Nunjucks Refactoring (Terms)
- converted term.html, external-link.html to nunjucks format
- changed pages.json variables to nunjucks compatible format. 
- Nunjucks is more strict than mustache: included templates get the current context, but nested objects must either be referenced explicitly or passed as local scope so set the scope in the parent terms.html file so partials could continue to be reusuable

HOFF-2042: Nunjucks Refactoring (Bullet list partial)
- converted bullet-list.html to nunjucks format
## Testing?
tested locally on ETA and ARE with beta version 24.0.0-nunjucks-refactoring-terms-bullet-list-beta - https://github.com/UKHomeOffice/eta/pull/81 and https://github.com/UKHomeOffice/AppealRightsExhausted/pull/201
## Screenshots (optional)
## Anything Else? (optional)
Note unit tests will still fail as those components have not yet been refactored
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests - Note unit tests will still fail as those components have not yet been refactored
- [x] I will squash the commits before merging
