### PR TITLE
HOFF-2029: Nunjucks Refactoring (Warning partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1826,24 +1826,46 @@ app.set("views", [
 
 The views are now available when calling `res.render('view-name')` from express.
 
+#### HOF Application
+
+When used in a hof application in conjunction with [express-partial-templates](https://github.com/UKHomeOffice/express-partial-templates) the contents of the views directory are added to `res.locals.partials`. These are added right to left so conflicting views are resolved from the left-most directory.
+
+```js
+var app = require("express")();
+
+app.set("view engine", "html");
+app.set("views", [
+  path.resolve(__dirname, "./path/to/views"),
+  require("hof").frontend.partials.views,
+]);
+app.use(require("express-partial-templates")(app));
+
+app.use(function (req, res, next) {
+  // res.locals.partials contains all views from the views dir in this repo
+  // which are extended by any local views in ./path/to/views
+  next();
+});
+```
+
+### Template partials - Components
+
 #### Details Component
- The `detailsComponent` macro can be used to display a details summary and text on a page. It can take three parameters:
 
-  `details`: An object containing the summary and text to display. The summary is required, but the text is optional.
+The `detailsComponent` macro can be used to display a details summary and text on a page. It can take three parameters:
 
-  `customSummary`: A string that can be used to override the summary in the details object.
+  - `details`: An object containing the summary and text to display. The summary is required, but the text is optional.
 
-  `customText`: A string that can be used to override the text in the details object.
+  - `customSummary`: A string that can be used to override the summary in the details object.
+
+  - `customText`: A string that can be used to override the text in the details object.
 
   This allows the component to be reused multiple times on the same page with different text.
   
   If `customSummary` or `customText` are not provided, the macro will use the values from the details object. If the details object does not contain a summary or text, it will default to an empty string.
 
- 
+**Example usage:**
 
- **Example usage:**
-
-  Use default summary and text from details object set in `pages.${route}.details`:
+Use default summary and text from details object set in `pages.${route}.details`:
 ```
 {
   "test-page": {
@@ -1873,25 +1895,45 @@ In your view file:
 {# Override both defaultsummary and text #}
 {{ detailsComponent(details, overrideSummary, overrideText) }}
 ```
-#### HOF Application
 
-When used in a hof application in conjunction with [express-partial-templates](https://github.com/UKHomeOffice/express-partial-templates) the contents of the views directory are added to `res.locals.partials`. These are added right to left so conflicting views are resolved from the left-most directory.
+#### Warning Component
 
-```js
-var app = require("express")();
+The `warningComponent` macro can be used to display a warning on a page. It takes one parameter:
 
-app.set("view engine", "html");
-app.set("views", [
-  path.resolve(__dirname, "./path/to/views"),
-  require("hof").frontend.partials.views,
-]);
-app.use(require("express-partial-templates")(app));
+  - `warning`: The warning text.
 
-app.use(function (req, res, next) {
-  // res.locals.partials contains all views from the views dir in this repo
-  // which are extended by any local views in ./path/to/views
-  next();
-});
+**Example usage:**
+
+To add a warning to a page, use text from `warning` set in `pages.${route}.warning`:
+```
+{
+  "test-page": {
+    "warning": "This is a warning"
+  }
+}
+```
+In your view file:
+```
+{% from "partials/warn.html" import warningComponent %}
+
+{{ warningComponent(warning) }}
+```
+
+Radio and Checkbox fields already include an optional warning component depending on if their `isWarning` field config is set. To set the warning text for such fields, set `warning` in `fields.${field}.warning`:
+```
+ "test-warn": {
+    "legend": "Which test would you like to choose?",
+    "hint": "Choose one of the options below and press continue.",
+    "options": {
+      "test1": {
+        "label": "Test 1"
+      },
+      "test2": {
+        "label": "Test 2"
+      }
+    },
+    "warning": "Radio Field Warning"
+  },
 ```
 
 ### Translations

--- a/frontend/template-mixins/partials/forms/option-group.html
+++ b/frontend/template-mixins/partials/forms/option-group.html
@@ -1,3 +1,5 @@
+{% from "partials/warn.html" import warningComponent %}
+
 <div id="{{ key }}-group" class="govuk-form-group{% if className %} {{ className }}{% endif %}{% if formGroupClassName %} {{ formGroupClassName }}{% endif %}{% if error %} govuk-form-group--error{% endif %}">
   <fieldset class="govuk-fieldset"{% if hint %} aria-describedby="{{ key }}-hint"{% endif %}>
     <legend class="govuk-fieldset__legend{% if isPageHeading %} govuk-fieldset__legend--l{% endif %}{% if legendClassName %} {{ legendClassName }}{% endif %}">
@@ -7,13 +9,7 @@
     </legend>
 
     {% if isWarning %}
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning</span>
-          {{ warning }}
-        </strong>
-      </div>
+      {{ warningComponent(warning) }}
     {% endif %}
 
     {% if hint %}

--- a/frontend/template-partials/views/partials/warn.html
+++ b/frontend/template-partials/views/partials/warn.html
@@ -1,7 +1,8 @@
-<div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
-        {{warning}}
-    </strong>
-</div>
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% macro warningComponent(warning) %}
+  {{ govukWarningText({
+    text: warning,
+    iconFallbackText: "Warning"
+  }) }}
+{% endmacro %}


### PR DESCRIPTION
## What? 
[HOFF-2029](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2029) - Nunjucks Refactoring (Warning partial)
## Why? 
Part of nunjucks refactoring work
## How? 
- convert warn.html to govukWarning component
- make warn.html a macro so it can be called in any page
- reorder template partials section of Readme and add documentation on warning component
## Testing?
Tested locally on eta and in hof/sandbox
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
