### PR TITLE
HOFF-2048: Nunjucks Refactoring (Confirm)

### DIFF
--- a/frontend/template-partials/views/confirm.html
+++ b/frontend/template-partials/views/confirm.html
@@ -1,8 +1,11 @@
-{{<partials-page}}
-  {{$page-content}}
-    {{#rows}}
-      {{> partials-summary-table}}
-    {{/rows}}
-    {{#input-submit}}confirm{{/input-submit}}
-  {{/page-content}}
-{{/partials-page}}
+{% extends "partials/page.html" %}
+
+{% from "partials/summary-table.html" import summaryTableComponent %}
+
+{% block page_content %}
+  {% for row in rows %}
+    {{ summaryTableComponent(row, t, baseUrl) }}
+  {% endfor %}
+
+  {{ inputSubmit("confirm") }}
+{% endblock %}

--- a/frontend/template-partials/views/partials/summary-table-row.html
+++ b/frontend/template-partials/views/partials/summary-table-row.html
@@ -1,14 +1,24 @@
-<div class="confirm-row">
-    {{#isSeparator}}
-    {{/isSeparator}}
-    {{^isSeparator}}
-        <dt class="confirm-label">{{label}}</dt>
-        <dd class="confirm-value" data-value="{{value}}">{{value}}</dd>
-    {{#changeLink}}
-        <dd><span><a class="govuk-link" href="{{changeLink}}" id="{{field}}-change-{{index}}">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a></span></dd>
-    {{/changeLink}}
-    {{^changeLink}}
-        <dd><span><a class="govuk-link" href="{{baseUrl}}{{step}}/edit#{{field}}" id="{{field}}-change">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a></span></dd>
-    {{/changeLink}}
-    {{/isSeparator}}
+<div class="govuk-summary-list__row">
+  {% if isSeparator %}
+  {% else %}
+    <dt class="govuk-summary-list__key">
+      {{ label }}
+    </dt>
+    <dd class="govuk-summary-list__value">
+      {{ value }}
+    </dd>
+    {% if not omitChangeLink %}
+      {% if changeLink %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ changeLink }}" id="{{ field }}-change-{{ index }}">{{ t('buttons.change') }}<span class="govuk-visually-hidden"> {{ changeLinkDescription }} from {{ value }}</span></a>
+        </dd>
+      {% else %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ baseUrl }}{{ step }}/edit#{{ field }}" id="{{ field }}-change">{{ t('buttons.change') }}<span class="govuk-visually-hidden"> {{ changeLinkDescription }} from {{ value }}</span></a>
+        </dd>
+      {% endif %}
+    {% else %}
+      <dd></dd>
+    {% endif %}
+  {% endif %}
 </div>

--- a/frontend/template-partials/views/partials/summary-table.html
+++ b/frontend/template-partials/views/partials/summary-table.html
@@ -1,8 +1,51 @@
-<div>
-  <h2 class="section-header">{{section}}</h2>
-</div>
-<dl>
-    {{#fields}}
-    {{^omitFromSummary}}{{> partials-summary-table-row}}{{/omitFromSummary}}
-    {{/fields}}
-</dl>
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro summaryTableComponent(row, t, baseUrl) %}
+  {% if row.section %}
+    <h2 class="govuk-heading-m">{{ row.section }}</h2>
+  {% endif %}
+
+  {% if row.fields %}
+    {% set summaryRows = [] %}
+
+    {% for field in row.fields %}
+      {% if not field.omitFromSummary %}
+        {% set actions = null %}
+
+        {% if not field.omitChangeLink %}
+          {% if field.changeLink %}
+            {% set actions = {
+              items: [{
+                href: field.changeLink,
+                text: t('buttons.change'),
+                visuallyHiddenText: field.changeLinkDescription + " from " + field.value,
+                attributes: { id: field.field + "-change-" + field.index }
+              }]
+            } %}
+          {% else %}
+            {% set actions = {
+              items: [{
+                href: baseUrl + field.step + "/edit#" + field.field,
+                text: t('buttons.change'),
+                visuallyHiddenText: field.changeLinkDescription + " from " + field.value,
+                attributes: { id: field.field + "-change" }
+              }]
+            } %}
+          {% endif %}
+        {% endif %}
+        {% set summaryRow = {
+          key: { text: field.label },
+          value: { text: field.value },
+          actions: actions
+        } %}
+
+        {% set summaryRows = summaryRows.concat([summaryRow]) %}
+      {% endif %}
+    {% endfor %}
+
+    {{ govukSummaryList({ 
+      classes: "govuk-!-margin-bottom-9",
+      rows: summaryRows 
+    }) }}
+  {% endif %}
+{% endmacro %}

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -98,15 +98,6 @@ module.exports = async (app, config) => {
     console.debug('govuk-frontend not resolved via require.resolve; ensure package is installed if needed');
   }
 
-  // include frontend/template-mixins/partials so imports like "template-mixins/partials..." can be resolved
-  try {
-    const mixinsDirectory = path.resolve(config.root || process.cwd(), 'frontend', 'template-mixins', 'partials');
-    nunjucksRoots.push(mixinsDirectory);
-  } catch (e) {
-    /* eslint-disable-next-line no-console */
-    console.debug('template-mixins/partials not resolved via require.resolve');
-  }
-
   // dedupe and keep only existing directories
   const uniqueRoots = Array.from(new Set(nunjucksRoots)).filter(p => {
     try { return fs.existsSync(p) && fs.lstatSync(p).isDirectory(); } catch (e) { return false; }


### PR DESCRIPTION
## What? 
[HOFF-2048](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2048) - Nunjucks Refactoring (Confirm)
## Why? 
Part of nunjucks refactoring work
## How? 
- remove adding mixinsDirectory in lib/settings as not necessary
-  convert summary-table.html to govukSummaryList component
- add omitChangeLink if/else as this is a feature that is reused in several hof services
- Change splitting logic from 3 to 2 files. `summary-table-row.html` is now a fallback for backwards compatibility
- the pre-existing `isSeparator` property can create accessibility issues and is not included with govukSummaryList.  It has been retained as fallback in `summary-table-row.html` and can be accessed by creating a `custom summary-table.html`.
## Testing?
Tested locally on eta and in hof/sandbox
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging

