### PR TITLE
HOFF-2055: Nunjucks Refactoring (File Upload mixin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1721,6 +1721,7 @@ date
 currency
 select
 inputText
+inputFile
 input-date
 input-amount-with-unit-select
 inputTextCompound

--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -92,13 +92,9 @@ module.exports = function (options) {
     const roots = [].concat(req.app.get('views')).concat(options.viewsDirectory);
     const View = req.app.get('view');
 
-    // create a nunjucks environment for resolving includes/partials from the
+    // use nunjucks environment for resolving includes/partials from the
     // project's views roots for this request.
-    const nunjucksEnv = (req && req.app && req.app.locals && req.app.locals.nunjucksEnv)
-      || new nunjucks.Environment(
-        new nunjucks.FileSystemLoader(roots, { noCache: process.env.NODE_ENV !== 'production' }),
-        { autoescape: true }
-      );
+    const nunjucksEnv = (req && req.app && req.app.locals && req.app.locals.nunjucksEnv);
 
 
     // helper: resolve a template file path by trying express View, configured viewsDirectory and app roots
@@ -343,6 +339,8 @@ module.exports = function (options) {
         ...(this.errors && this.errors[key] && { 'aria-invalid': 'true' })
       };
 
+      const disabled = field.disabled;
+
       return Object.assign({}, extension, {
         id: key,
         className: extension.className || classNames(field),
@@ -366,6 +364,7 @@ module.exports = function (options) {
         child: field.child,
         isPageHeading: field.isPageHeading,
         attributes: attributes,
+        disabled: disabled,
         prefix: isPrefixOrSuffix(field.attributes, 'prefix'),
         suffix: isPrefixOrSuffix(field.attributes, 'suffix'),
         isMaxlengthOrMaxword: maxlength(field) || extension.maxlength || maxword(field) || extension.maxword,

--- a/frontend/template-mixins/partials/forms/input-text-group.html
+++ b/frontend/template-mixins/partials/forms/input-text-group.html
@@ -1,4 +1,5 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
 {#-------------------------------------------#}
 {#  Set form group and label classes         #}
@@ -77,7 +78,12 @@
   autocomplete: autocomplete,
   value: value,
   pattern: pattern,
-  attributes: attributes
+  attributes: attributes,
+  disabled: disabled
 } %}
 
-{{ govukInput(args) }}
+{% if type == "file" %}
+  {{ govukFileUpload(args) }}
+{% else %}
+  {{ govukInput(args) }}
+{% endif %}

--- a/frontend/template-partials/views/partials/form.html
+++ b/frontend/template-partials/views/partials/form.html
@@ -1,8 +1,6 @@
-{% macro form(csrf_token) %}
-<form action="" method="POST" {% block encoding %}{% endblock %} autocomplete="off" novalidate="true" spellcheck="false">
-  {% block intro %}
+{% macro form(encoding="", intro="", csrf_token) %}
+<form action="" method="POST" {{ encoding }} autocomplete="off" novalidate="true" spellcheck="false">
   {% if intro %}<p>{{ intro }}</p>{% endif %}
-  {% endblock %}
   {{ caller() }}
   {% if csrf_token %}
     <input type="hidden" name="x-csrf-token" value="{{ csrf_token }}" />

--- a/frontend/template-partials/views/partials/page.html
+++ b/frontend/template-partials/views/partials/page.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% call form(csrf_token) %}
+  {% call form(encoding=encoding, intro=intro, csrf_token) %}
     {% block page_content %}{% endblock %}
   {% endcall %}
   {% include "partials/session-timeout-warning.html" %}

--- a/frontend/themes/gov-uk/index.js
+++ b/frontend/themes/gov-uk/index.js
@@ -6,4 +6,6 @@ const partials = require('../../template-partials');
 module.exports = options => template(options);
 
 module.exports.views = [path.resolve(__dirname, './views'), partials.views];
+module.exports.views = [path.resolve(__dirname, './views'), partials.views,
+  path.resolve(__dirname, '../../../components')];
 module.exports.translations = partials.resources();

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -18,13 +18,19 @@ describe('Template Mixins', () => {
   });
 
   beforeEach(() => {
+    const nunjucksEnv = new nunjucks.Environment();
+
     req = reqres.req({
       translate: a => a
     });
 
+    req.app = req.app || {};
+    req.app.locals = {
+      nunjucksEnv
+    };
+
     res = {
       locals: {
-        nunjucksEnv: new nunjucks.Environment(),
         options: {
           fields: {}
         }
@@ -1003,6 +1009,32 @@ describe('Template Mixins', () => {
           expect.any(String),
           expect.objectContaining({
             pattern: '[0-9]*'
+          })
+        );
+      });
+    });
+
+    describe('inputFile', () => {
+      it('adds a function to res.locals', () => {
+        middleware(req, res, next);
+        expect(typeof res.locals.inputFile).toBe('function');
+      });
+
+      it('returns an object', () => {
+        middleware(req, res, next);
+        const result = res.locals.inputFile();
+
+        expect(typeof result).toBe('object');
+        expect(result).not.toBeNull();
+      });
+
+      it('adds a `file` type attribute to file inputs', () => {
+        middleware(req, res, next);
+        res.locals.inputFile('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            type: 'file'
           })
         );
       });


### PR DESCRIPTION
## What? 
[HOFF-2055](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2055) - Nunjucks Refactoring (Input File Mixin)
## Why? 
Part of nunjucks refactoring work
## How? 
- added if/else statement to  input-text-group.html to use govukFileUpload component if input type is set to 'file'
- added disabled attribute to args
- configured disabled property in template-mixins
- removed creating new nunjucks environment in template-mixins - slows down performance
- updated mixin name in readme
- fixed encoding and intro not being called with form
- added components path to views, so component templates can be picked up
## Testing?
Tested locally on rotm
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
