### PR TITLE
HOFF-2046: Nunjucks Refactoring(Table partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1937,6 +1937,51 @@ Radio and Checkbox fields already include an optional warning component dependin
   },
 ```
 
+#### Table Component
+
+The `tableComponent` macro can be used to display a table on a page. It takes one parameter:
+
+  - `tableName`: An object containing the following keys:
+    - `headers` : an array with the text for each table header
+    - `rows`: an array of arrays with the text for each table row
+    - `caption`: the table caption (Optional)
+    - `firstCellIsHeader`: if set to true, it puts the first element of the each array in the rows array in bold (Optional)
+  
+**Example usage:**
+
+Set your table object in the relevant `.json` file:
+```
+"test_table": {
+  "headers": [
+    "Name",
+    "Purpose",
+    "Expires"
+  ],
+  "rows": [
+    [
+      "seen_cookie_message",
+      "Lets us know you’ve already seen our cookie message",
+      "1 month"
+    ],
+    [
+      "cookie_preferences",
+      "Lets us know that you’ve saved your cookie consent settings",
+      "1 month"
+    ]
+  ],
+  "caption": "Table caption" // optional
+  "firstCellIsHeader": true // optional
+}
+```
+In your view file:
+```
+{% from "partials/table.html" import tableComponent %}
+
+{{ tableComponent(test_table) }}
+
+```
+
+
 ### Translations
 
 The provided translations are designed to be used in conjunction with a translations library such as [i18n-future](https://github.com/lennym/i18n-future).

--- a/frontend/template-partials/translations/src/cy/cookies.json
+++ b/frontend/template-partials/translations/src/cy/cookies.json
@@ -28,7 +28,7 @@
   },
   "intro-cookie": "Neges cyflwyno cwcis",
   "intro-cookie-message": "Pan fyddwch yn defnyddio’r gwasanaeth am y tro cyntaf rydym yn dangos ‘neges cwcis’. Yna rydym yn storio cwci ar eich cyfrifiadur fel nad yw’n dangos y neges yma i chi eto.",
-  "intro-cookie-table": {
+  "intro_cookie_table": {
     "headers": [
       "Enw",
       "Pwrpas",

--- a/frontend/template-partials/translations/src/en/cookies.json
+++ b/frontend/template-partials/translations/src/en/cookies.json
@@ -28,7 +28,7 @@
   },
   "intro-cookie": "Introductory cookie message",
   "intro-cookie-message": "When you first use the service we show a ‘cookie message’. We then store a cookie on your computer so it knows not to show this message again.",
-  "intro-cookie-table": {
+  "intro_cookie_table": {
     "headers": [
       "Name",
       "Purpose",

--- a/frontend/template-partials/views/cookies.html
+++ b/frontend/template-partials/views/cookies.html
@@ -1,4 +1,6 @@
-{{<layout}}
+{% extends "layout.html" %}
+
+{% from "partials/table.html" import tableComponent %}
 
   {{$propositionHeader}}{{/propositionHeader}}
 
@@ -23,9 +25,9 @@
       {{/indent-intro}}
       <h2>{{intro-cookie}}</h2>
       <p>{{intro-cookie-message}}</p>
-      {{#intro-cookie-table}}
-        {{> partials-table}}
-      {{/intro-cookie-table}}
+      {% if intro_cookie_table %}
+        {{ tableComponent(intro_cookie_table) }}
+      {% endif %} 
       <h2>{{session-cookies}}</h2>
       <p>{{session-cookies-content}}</p>
       {{#session-cookies-table}}
@@ -43,9 +45,10 @@
         {{/indent-intro}}
         <h2>{{intro-cookie}}</h2>
         <p>{{intro-cookie-message}}</p>
-        {{#intro-cookie-table}}
-          {{> partials-table}}
-        {{/intro-cookie-table}}
+        {% if intro_cookie_table %}
+          {% set ctx = intro_cookie_table %}
+          {% include "partials/table.html" %}
+        {% endif %} 
           <h2>{{session-cookies}}</h2>
           <p>{{session-cookies-content}}</p>
           {{#session-cookies-table}}
@@ -81,4 +84,3 @@
     {{/hasGoogleAnalytics}}
 
   {{/content}}
-{{/layout}}

--- a/frontend/template-partials/views/partials/table.html
+++ b/frontend/template-partials/views/partials/table.html
@@ -1,18 +1,33 @@
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      {{#headers}}
-        <th scope="col" class="govuk-table__header app-custom-class">{{.}}</th>
-      {{/headers}}
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body"> 
-    {{#rows}}
-      <tr class="govuk-table__row">
-        {{#.}}
-          <td  class="govuk-table__cell">{{.}}</td>
-        {{/.}}
-      </tr>
-    {{/rows}}
-  </tbody>
-</table>
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro tableComponent(tableName) %}
+  {% set head = [] %}
+  {% for header in tableName.headers %}
+    {% set head = head.concat([{
+      text: header,
+      classes: "app-custom-class"
+    }]) %}
+  {% endfor %}
+
+  {% set tableRows = [] %}
+  {% for row in tableName.rows %}
+    {% set tableCell = [] %}
+    {% for cell in row %}
+      {% set tableCell = tableCell.concat([{
+        text: cell
+      }]) %}
+    {% endfor %}
+    
+    {% set tableRows = tableRows.concat([tableCell]) %}
+  {% endfor %}
+
+  {% set args = {
+    caption: tableName.caption,
+    captionClasses: "govuk-table__caption--m",
+    firstCellIsHeader: tableName.firstCellIsHeader,
+    head: head,
+    rows: tableRows
+  } %}
+
+  {{ govukTable(args) }}
+{% endmacro %}


### PR DESCRIPTION
## What? 
[HOFF-2046](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2046) - Nunjucks Refactoring (Table partial)
## Why? 
Part of nunjucks refactoring work
## How? 
- converted table.html to govuk component and make table.html a  macro
  - can now set table caption
  - can now make first cell header
- add nunjucks tableComponent to cookies.html (the rest of cookies.html will be addressed in a separate ticket)
- update readme
## Testing?
Tested locally in hof/sandbox
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
