### PR TITLE
HOFF-2028: Nunjucks Refactoring(Checkbox Group Mixin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1732,7 +1732,7 @@ radioGroup
 checkbox
 checkbox-compound
 checkbox-required
-checkbox-group
+checkboxGroup
 inputSubmit
 textarea
 qs

--- a/components/summary/index.js
+++ b/components/summary/index.js
@@ -163,7 +163,7 @@ module.exports = SuperClass => class extends SuperClass {
 
   isCheckbox(key, req) {
     return req.sessionModel.get(key) && req.form.options.fieldsConfig[key] &&
-      (req.form.options.fieldsConfig[key].mixin === 'checkbox-group' ||
+      (req.form.options.fieldsConfig[key].mixin === 'checkboxGroup' ||
         req.form.options.fieldsConfig[key].mixin === 'radioGroup');
   }
 

--- a/controller/controller.js
+++ b/controller/controller.js
@@ -212,7 +212,7 @@ module.exports = class Controller extends BaseController {
         if (req.form && req.form.options && req.form.options.fields) {
           const field = req.form.options.fields[key];
           // get first option for radios and checkbox
-          if (field.mixin === 'radioGroup' || field.mixin === 'checkbox-group') {
+          if (field.mixin === 'radioGroup' || field.mixin === 'checkboxGroup') {
             // get first option for radios and checkbox where there is a toggle
             if (typeof field.options[0] === 'object') {
               req.form.errors[key].errorLinkId = key + '-' + field.options[0].value;

--- a/controller/validation/index.js
+++ b/controller/validation/index.js
@@ -63,7 +63,7 @@ function validate(fields) {
     debug(`Validating field: "${key}" with value: "${value}"`);
 
     function shouldValidate() {
-      // validationLink used to validates multiple dependent fields in checkbox-group
+      // validationLink used to validates multiple dependent fields in checkboxGroup
       let dependent = fields[key].dependent || fields[key].validationLink;
 
       if (typeof dependent === 'string') {

--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -8,7 +8,7 @@ const nunjucks = require('nunjucks');
 
 const renderer = require('./render');
 
-const PANELMIXIN = 'partials/mixins/panel';
+const CONDITIONAL_MIXIN = 'partials/mixins/conditional';
 const PARTIALS = [
   'partials/forms/input-text-group',
   'partials/forms/input-text-date',
@@ -238,11 +238,11 @@ module.exports = function (options) {
       if (match) {
         return readTemplate(res.locals.partials['partials-' + match[1]]);
       } else if (child === 'html' || res.locals[child]) {
-        if (res.locals.partials['partials-mixins-panel']) {
-          return readTemplate(res.locals.partials['partials-mixins-panel']);
+        if (res.locals.partials['partials-mixins-conditional']) {
+          return readTemplate(res.locals.partials['partials-mixins-conditional']);
         }
-        const panelPath = path.join(options.viewsDirectory, PANELMIXIN);
-        return readTemplate(panelPath);
+        const conditionalPath = path.join(options.viewsDirectory, CONDITIONAL_MIXIN);
+        return readTemplate(conditionalPath);
       }
       return child;
     }
@@ -399,6 +399,8 @@ module.exports = function (options) {
         let child;
         let optionHint;
         let useHintText;
+        let behaviour;
+        let divider;
 
         if (typeof obj === 'string') {
           value = obj;
@@ -412,6 +414,8 @@ module.exports = function (options) {
           child = obj.child;
           useHintText = obj.useHintText;
           optionHint = obj.hint || 'fields.' + pKey + '.options.' + obj.value + '.hint';
+          behaviour = obj.behaviour;
+          divider = obj.divider;
         }
 
         if (this.values && this.values[key] !== undefined) {
@@ -443,7 +447,12 @@ module.exports = function (options) {
           radioOption: opts.type === 'radio',
           toggle: toggle,
           child: child,
-          optionHint: renderedOptionHint
+          optionHint: renderedOptionHint,
+          behaviour: behaviour,
+          divider: divider,
+          renderMixin: renderChild.bind({
+            ...this
+          })
         };
       }, this);
 
@@ -540,7 +549,7 @@ module.exports = function (options) {
           type: 'radio'
         }
       },
-      'checkbox-group': {
+      checkboxGroup: {
         path: 'partials/forms/checkbox-group',
         renderWith: optionGroup,
         options: {

--- a/frontend/template-mixins/partials/forms/checkbox-group.html
+++ b/frontend/template-mixins/partials/forms/checkbox-group.html
@@ -1,47 +1,173 @@
-<div id="{{key}}-group" class="govuk-form-group{{#className}} {{className}} {{/className}}{{#formGroupClassName}} {{formGroupClassName}}{{/formGroupClassName}}{{#error}} govuk-form-group--error{{/error}}">
-    <fieldset class="govuk-fieldset" {{#hint}} aria-describedby="{{key}}-hint"{{/hint}}>
-        <legend class="govuk-fieldset__legend {{#isPageHeading}}govuk-fieldset__legend--l{{/isPageHeading}}{{#legendClassName}} {{legendClassName}}{{/legendClassName}}">
-            {{#isPageHeading}}<h1 class="govuk-fieldset__heading">{{/isPageHeading}}
-                {{legend}}
-            {{#isPageHeading}}</h1>{{/isPageHeading}}
-        </legend>
-        {{#isWarning}}
-        <div class="govuk-warning-text">
-            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-            <strong class="govuk-warning-text__text">
-              <span class="govuk-warning-text__assistive">Warning</span>
-             {{warning}}
-            </strong>
-          </div>
-        {{/isWarning}}
-        {{#hint}}<div id="{{key}}-hint" class="govuk-hint">{{{hint}}}</div>{{/hint}}
-        {{#error}}
-        <p id="{{key}}-error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{error.message}}
-        </span>
-        {{/error}}
-        {{{detail}}}
-		<div class="govuk-checkboxes" data-module="govuk-checkboxes">
-        {{#options}}
-        <div class="govuk-checkboxes__item">
-            <input
-				class="govuk-checkboxes__input"
-                type="{{type}}"
-                name="{{key}}"
-                id="{{key}}-{{value}}"
-                value="{{value}}"                
-                {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
-                {{#selected}} checked="checked"{{/selected}}
-                {{^error}}{{#optionHint}} aria-describedby="{{key}}-{{value}}-hint"{{/optionHint}}{{^optionHint}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}{{/optionHint}}{{/error}}
-                {{#error}} aria-describedby="{{key}}-error" aria-invalid="true"{{/error}}
-            >
-            <label class="govuk-label govuk-checkboxes__label" for="{{key}}-{{value}}">
-                {{{label}}}
-                {{#optionHint}}<div id="{{key}}-{{value}}-item-hint" class="govuk-hint">{{optionHint}}</div>{{/optionHint}}
-            </label>
+ {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+ {% from "partials/warn.html" import warningComponent %}
+
+{% set items = [] %}
+
+{% for option in options %}
+{#------------------------------------------#}
+{#  Set conditional HTML                    #}
+{#------------------------------------------#}
+  {% set conditionalHtml = "" %}
+  {% set conditionalHtml %}
+    {{ option.renderMixin(option) | safe }}
+  {% endset %}
+
+{#------------------------------------------#}
+{#  Set checkbox items                      #}
+{#------------------------------------------#}
+  {# Add divider BEFORE the exclusive option #}
+  {% if option.divider !== "after" and option.behaviour === "exclusive" %}
+    {% set items = items.concat([{
+      divider: "or"
+    }]) %}
+  {% endif %}
+
+  {% set items = items.concat([{
+    value: option.value,
+    html: option.label | safe,
+    checked: option.selected or false,
+    id: key + '-' + option.value,
+    name: key,
+    hint: option.optionHint and {
+      text: option.optionHint
+    } or null,
+    conditional: option.toggle and {
+      html: conditionalHtml
+    } or null,
+    behaviour: option.behaviour
+  }]) %}
+
+  {# Add divider AFTER the exclusive option #}
+  {% if option.divider === "after" and option.behaviour === "exclusive" %}
+    {% set items = items.concat([{
+      divider: "or"
+    }]) %}
+  {% endif %}
+{% endfor %}
+
+{#-------------------------------------------#}
+{#  Set form group and legend classes        #}
+{#-------------------------------------------#}
+{% set formGroupClasses = "" %}
+{% set legendClasses = "" %}
+{% set classes = className or "" %}
+{% set formGroupClasses = formGroupClasses + formGroupClassName if formGroupClassName %}
+{% set legendClasses = legendClasses + "govuk-fieldset__legend--l " if isPageHeading %}
+
+
+{#------------------------------------------#}
+{#  Set hint object if hint exists          #}
+{#------------------------------------------#}
+{% set hintObj = null %}
+{% if hint %}
+  {% set hintObj = {
+    html: hint | safe,
+    classes: "govuk-hint"
+  } %}
+{% endif %}
+
+{#------------------------------------------#}
+{#  Set error object if error exists        #}
+{#------------------------------------------#}
+{% set errorObj = null %}
+{% if error %}
+  {% set errorObj = {
+    text: error.message,
+    id: error.id
+  } %}
+{% endif %}
+
+{#----------------------------------------------#}
+{#  Set beforeInput HTML                        #}
+{#----------------------------------------------#}
+{% if isWarning %}
+  {% set beforeInputObj = { html: warningComponent(warning) | safe } %}
+{% else %}
+  {% set beforeInputObj = null %}
+{% endif %}
+
+{#----------------------------------------------#}
+{#  Set govukCheckboxes args                    #}
+{#----------------------------------------------#}
+{% set args = {
+  formGroup: {
+    classes: formGroupClasses,
+    beforeInputs: beforeInputObj
+  },
+  fieldset: {
+    legend: {
+      html: legend,
+      isPageHeading: isPageHeading,
+      classes: legendClasses + legendClassName
+    }
+  },
+  idPrefix: key,
+  name: key,
+  classes: classes,
+  hint: hintObj,
+  errorMessage: errorObj,
+  items: items
+} %}
+
+{% if isWarning %}
+  <div class="govuk-form-group{% if errorObj %} govuk-form-group--error{% endif %} {{ formGroupClasses }}">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend {{ legendClasses }}">
+        {{ legend | safe }}
+      </legend>
+      {% if isWarning %}
+        {{ warningComponent(warning) }}
+      {% endif %}
+
+      {% if hintObj %}
+        <div id="{{ key }}-hint" class="{{ hintObj.classes }}">
+          {{ hintObj.html | safe }}
         </div>
-        {{#renderChild}}{{/renderChild}}
-        {{/options}}
-		</div>
+      {% endif %}
+
+      {% if errorObj %}
+        <span id="{{ errorObj.id }}" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> {{ errorObj.text }}
+        </span>
+      {% endif %}
+
+      <div class="govuk-checkboxes {{ classes }}" data-module="govuk-checkboxes">
+        {% for item in items %}
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input"
+                  id="{{ item.id }}"
+                  name="{{ item.name }}"
+                  type="checkbox"
+                  value="{{ item.value }}"
+                  {% if item.checked %}checked{% endif %}
+                  {% if item.conditional %}
+                    aria-controls="conditional-{{ item.id }}"
+                  {% endif %}
+                  {% for attr, val in item.attributes|default({}) %}
+                    {{ attr }}="{{ val }}"
+                  {% endfor %}>
+
+            <label class="govuk-label govuk-checkboxes__label" for="{{ item.id }}">
+              {{ item.html | safe }}
+            </label>
+
+            {% if item.hint %}
+              <div class="govuk-hint govuk-checkboxes__hint">
+                {{ item.hint.text | safe }}
+              </div>
+            {% endif %}
+          </div>
+          {% if item.conditional %}
+            <div id="conditional-{{ item.id }}"
+            class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}"
+            aria-hidden="{% if not item.checked %}true{% else %}false{% endif %}">
+              {{ item.conditional.html | safe }}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
     </fieldset>
-</div>
+  </div>
+{% else %}
+ {{ govukCheckboxes(args) }}
+{% endif %}

--- a/frontend/template-mixins/partials/mixins/conditional.html
+++ b/frontend/template-mixins/partials/mixins/conditional.html
@@ -1,0 +1,1 @@
+{{renderMixin(option) | safe }}

--- a/frontend/template-mixins/partials/mixins/panel.html
+++ b/frontend/template-mixins/partials/mixins/panel.html
@@ -1,4 +1,0 @@
-<div id="{{toggle}}-panel" class="{{#radioOption}}govuk-radios__conditional{{/radioOption}}
-  {{^radioOption}}govuk-checkboxes__conditional{{/radioOption}}">
-  {{#renderMixin}}{{/renderMixin}}
-</div>

--- a/sandbox/apps/sandbox/fields.js
+++ b/sandbox/apps/sandbox/fields.js
@@ -46,7 +46,7 @@ module.exports = {
   },
   incomeTypes: {
     isPageHeading: 'true',
-    mixin: 'checkbox-group',
+    mixin: 'checkboxGroup',
     labelClassName: 'visuallyhidden',
     validate: ['required'],
     options: [

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -1464,18 +1464,15 @@ describe('Template Mixins', () => {
       });
     });
 
-    describe('checkbox-group', () => {
-      beforeEach(() => {
-      });
-
+    describe('checkboxGroup', () => {
       it('adds a function to res.locals', () => {
         middleware(req, res, next);
-        res.locals['checkbox-group'].should.be.a('function');
+        expect(typeof res.locals.checkboxGroup).toBe('function');
       });
 
-      it('returns a function', () => {
+      it('returns an object', () => {
         middleware(req, res, next);
-        res.locals['checkbox-group']().should.be.a('function');
+        expect(typeof res.locals.checkboxGroup()).toBe('object');
       });
 
       it('looks up field options', () => {
@@ -1489,37 +1486,36 @@ describe('Template Mixins', () => {
               value: 'bar'
             }, {
               label: 'Baz',
-              hint: 'baz hint',
               value: 'baz'
             }]
           }
         };
         middleware(req, res, next);
-        res.locals['checkbox-group']().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match(function (value) {
-          const options = [{
-            label: 'Foo',
-            value: 'foo',
-            type: 'checkbox',
-            selected: false,
-            toggle: undefined
-          }, {
-            label: 'Bar',
-            value: 'bar',
-            type: 'checkbox',
-            selected: false,
-            toggle: undefined
-          }, {
-            label: 'Baz',
-            value: 'baz',
-            hint: 'baz hint',
-            type: 'checkbox',
-            selected: false,
-            toggle: undefined
-          }];
-          return _.every(value.options, function (option, index) {
-            return _.isMatch(option, options[index]);
-          });
+        res.locals.checkboxGroup('field-name');
+        const options = renderSpy.mock.calls[renderSpy.mock.calls.length - 1][1].options;
+
+        expect(options[0]).toEqual(expect.objectContaining({
+          label: 'Foo',
+          value: 'foo',
+          type: 'checkbox',
+          selected: false,
+          toggle: undefined
+        }));
+
+        expect(options[1]).toEqual(expect.objectContaining({
+          label: 'Bar',
+          value: 'bar',
+          type: 'checkbox',
+          selected: false,
+          toggle: undefined
+        }));
+
+        expect(options[2]).toEqual(expect.objectContaining({
+          label: 'Baz',
+          value: 'baz',
+          type: 'checkbox',
+          selected: false,
+          toggle: undefined
         }));
       });
 
@@ -1530,10 +1526,12 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals['checkbox-group']().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          className: 'abc def'
-        }));
+        res.locals.checkboxGroup('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            className: 'abc def'
+          }));
       });
 
       it('should have role: group', () => {
@@ -1542,10 +1540,12 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals['checkbox-group']().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          role: 'group'
-        }));
+        res.locals.checkboxGroup('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            role: 'group'
+          }));
       });
 
       it('adds `legendClassName` if it exists as a string or an array', () => {
@@ -1564,39 +1564,50 @@ describe('Template Mixins', () => {
 
         middleware(req, res, next);
 
-        res.locals['checkbox-group']().call(res.locals, 'field-name-1');
-        render.should.have.been.calledWith(sinon.match({
-          legendClassName: 'abc def'
-        }));
+        res.locals.checkboxGroup('field-name-1');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            legendClassName: 'abc def'
+          }));
 
-        res.locals['checkbox-group']().call(res.locals, 'field-name-2');
-        render.should.have.been.calledWith(sinon.match({
-          legendClassName: 'abc def'
-        }));
+        res.locals.checkboxGroup('field-name-2');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            legendClassName: 'abc def'
+          }));
       });
 
       it('uses locales translation for legend if a field value isn\'t provided', () => {
-        req.translate = sinon.stub().withArgs('fields.field-name.legend').returns('Field legend');
+        req.translate = jest.fn('fields.field-name.legend').mockReturnValue('Field legend');
         res.locals.options.fields = {
           'field-name': {}
         };
         middleware(req, res, next);
-        res.locals['checkbox-group']().call(res.locals, 'field-name');
-        render.should.have.been.calledWithExactly(sinon.match({
-          legend: 'Field legend'
-        }));
+        res.locals.checkboxGroup('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            legend: 'Field legend'
+          }));
       });
 
       it('uses locales translation for hint if a field value isn\'t provided', () => {
-        req.translate = sinon.stub().withArgs('fields.field-name.hint').returns('Field hint');
+        req.translate = jest.fn('fields.field-name.hint').mockReturnValue('Field hint');
         res.locals.options.fields = {
           'field-name': {}
         };
         middleware(req, res, next);
-        res.locals['checkbox-group']().call(res.locals, 'field-name');
-        render.should.have.been.calledWithExactly(sinon.match({
-          hint: 'Field hint'
-        }));
+        res.locals.checkboxGroup('field-name');
+        // render.should.have.been.calledWithExactly(sinon.match({
+        //   hint: 'Field hint'
+        // }));
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            hint: 'Field hint'
+          }));
       });
 
       it('doesn\'t add a hint if the hint doesn\'t exist in locales', () => {
@@ -1604,10 +1615,12 @@ describe('Template Mixins', () => {
           'field-name': {}
         };
         middleware(req, res, next);
-        res.locals['checkbox-group']().call(res.locals, 'field-name');
-        render.should.have.been.calledWithExactly(sinon.match({
-          hint: null
-        }));
+        res.locals.checkboxGroup('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            hint: null
+          }));
       });
 
       describe('multiple options selected', () => {
@@ -1626,18 +1639,27 @@ describe('Template Mixins', () => {
               }]
             }
           };
+          renderSpy.mockClear();
         });
+
+        function getSelectedValues() {
+          const call = renderSpy.mock.calls[0];
+          const arg = call[1];
+          const options = arg.options.fields['field-name'].options;
+          const values = arg.values['field-name'] || [];
+
+          return options
+            .filter(option => values.includes(option.value))
+            .map(option => option.value);
+        }
 
         it('marks foo and bar as selected', () => {
           res.locals.values = {
             'field-name': ['foo', 'bar']
           };
           middleware(req, res, next);
-          res.locals['checkbox-group']().call(res.locals, 'field-name');
-          const options = render.lastCall.args[0].options;
-          _.pluck(options.filter(function (option) {
-            return option.selected;
-          }), 'value').should.be.eql(['foo', 'bar']);
+          res.locals.checkboxGroup('field-name');
+          expect(getSelectedValues()).toEqual(['foo', 'bar']);
         });
 
         it('marks foo, bar and baz as selected', () => {
@@ -1645,11 +1667,8 @@ describe('Template Mixins', () => {
             'field-name': ['foo', 'bar', 'baz']
           };
           middleware(req, res, next);
-          res.locals['checkbox-group']().call(res.locals, 'field-name');
-          const options = render.lastCall.args[0].options;
-          _.pluck(options.filter(function (option) {
-            return option.selected;
-          }), 'value').should.be.eql(['foo', 'bar', 'baz']);
+          res.locals.checkboxGroup('field-name');
+          expect(getSelectedValues()).toEqual(['foo', 'bar', 'baz']);
         });
 
         it('marks foo and baz as selected', () => {
@@ -1657,11 +1676,8 @@ describe('Template Mixins', () => {
             'field-name': ['foo', 'baz']
           };
           middleware(req, res, next);
-          res.locals['checkbox-group']().call(res.locals, 'field-name');
-          const options = render.lastCall.args[0].options;
-          _.pluck(options.filter(function (option) {
-            return option.selected;
-          }), 'value').should.be.eql(['foo', 'baz']);
+          res.locals.checkboxGroup('field-name');
+          expect(getSelectedValues()).toEqual(['foo', 'baz']);
         });
 
         it('marks bar as selected', () => {
@@ -1669,11 +1685,8 @@ describe('Template Mixins', () => {
             'field-name': ['bar']
           };
           middleware(req, res, next);
-          res.locals['checkbox-group']().call(res.locals, 'field-name');
-          const options = render.lastCall.args[0].options;
-          _.pluck(options.filter(function (option) {
-            return option.selected;
-          }), 'value').should.be.eql(['bar']);
+          res.locals.checkboxGroup('field-name');
+          expect(getSelectedValues()).toEqual(['bar']);
         });
       });
     });

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -69,7 +69,7 @@ module.exports = class Helpers {
    * @returns {Boolean} - if the mixin has associated options
    */
   static hasOptions(mixin) {
-    return mixin === 'radioGroup' || mixin === 'checkbox-group' || mixin === 'select';
+    return mixin === 'radioGroup' || mixin === 'checkboxGroup' || mixin === 'select';
   }
 
   /**
@@ -110,7 +110,7 @@ module.exports = class Helpers {
    * Utility function which looks up translations with fallback values
    * If the translation is for a field, it will first try fields.key.summary
    * If this fails it will try fields.key.label, if this fails it will try
-   * fields.key.legend (radioGroup and checkbox-group).
+   * fields.key.legend (radioGroup and checkboxGroup).
    *
    * If the translation is not for a field it will first try pages.key.summary,
    * if this fails it will fallback to pages.keys.header.


### PR DESCRIPTION
## What? 
- [HOFF-2028](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2028) - Nunjucks Refactoring (Checkbox Group Mixin) and
-  [HOFF-2047](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2047)- Nunjucks Refactoring (Panel Mixin - radio/checkbox toggle)

## Why? 
Part of nunjucks refactoring work

## How? 
- converted checkbox-group.html to nunjucks format.
-  added if/else statement to use raw HTML for checkboxes with warnings since it cannot be added dynamically under v4 of govuk-frontend (only available from v5.2.0). It has been included in the nunjucks govuk component version and once the govuk-frontend version has been updated, the if/else statement and rawHTML version can be removed

- added exclusive behaviour option and divider

- changed panel.html to conditional.html to avoid confusion with govuk panel component and amend related path names.

 - amended optionGroup function in template-mixins.js so that conditional fields render with all their attributes and validations.

- changed checkbox-group mixin name to checkboxGroup

- refactored checkbox-group unit tests

## Testing?
- tested locally in firearms, brp and hof/sandbox 
## Screenshots (optional)
## Anything Else? (optional)
Note other unit tests will still fail as those components have not yet been refactored
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests  - other unit tests will still fail as those components have not yet been refactored
- [x] I will squash the commits before merging
