### PR TITLE
HOTFIX: Nunjucks refactoring

### DIFF
--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -339,7 +339,7 @@ module.exports = function (options) {
         ...(this.errors && this.errors[key] && { 'aria-invalid': 'true' })
       };
 
-      const disabled = field.disabled;
+      const disabled = field.disabled === true || field.disabled === 'true';
 
       return Object.assign({}, extension, {
         id: key,

--- a/frontend/template-mixins/partials/forms/checkbox-group.html
+++ b/frontend/template-mixins/partials/forms/checkbox-group.html
@@ -98,7 +98,7 @@
     legend: {
       html: legend,
       isPageHeading: isPageHeading,
-      classes: legendClasses + legendClassName
+      classes: legendClasses + (legendClassName if legendClassName)
     }
   },
   idPrefix: key,

--- a/frontend/template-mixins/partials/forms/option-group.html
+++ b/frontend/template-mixins/partials/forms/option-group.html
@@ -97,7 +97,7 @@
     legend: {
       html: legend,
       isPageHeading: isPageHeading,
-      classes: legendClasses + legendClassName
+      classes: legendClasses + (legendClassName if legendClassName)
     }
   },
   idPrefix: key,

--- a/frontend/template-partials/views/accessibility.html
+++ b/frontend/template-partials/views/accessibility.html
@@ -8,30 +8,30 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">{{ t('accessibility.header') }}</h1>
         <p class="govuk-body">{{ t('accessibility.intro-p2') }}</p>
-        <ul class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
             <li>{{ t('accessibility.intro-p2-li1') }}</li>
             <li>{{ t('accessibility.intro-p2-li2') }}</li>
             <li>{{ t('accessibility.intro-p2-li3') }}</li>
             <li>{{ t('accessibility.intro-p2-li4') }}</li>
             <li>{{ t('accessibility.intro-p2-li5') }}</li>
         </ul>
-        <p class="govuk-body">{{ t('accessibility.intro-p3-pre-link') }} <a href="https://mcmw.abilitynet.org.uk/">{{ t('accessibility.intro-p3-link') }}</a> {{ t('accessibility.intro-p3-post-link') }}</p>
+        <p class="govuk-body">{{ t('accessibility.intro-p3-pre-link') }} <a class="govuk-link" href="https://mcmw.abilitynet.org.uk/">{{ t('accessibility.intro-p3-link') }}</a> {{ t('accessibility.intro-p3-post-link') }}</p>
         <h2 class="govuk-heading-m">{{ t('accessibility.how-accessible-header') }}</h2>
         <p class="govuk-body">{{ t('accessibility.how-accessible-p1') }}</p>
-        <ul class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
             <li>{{ t('accessibility.how-accessible-p1-li1') }}</li>
             <li>{{ t('accessibility.how-accessible-p1-li2') }}</li>
         </ul>
         <h2 class="govuk-heading-m">{{ t('accessibility.reporting-header') }}</h2>
         <p class="govuk-body">{{ t('accessibility.reporting-p1') }}</p>
         <ul class="govuk-list">
-            <li>{{ t('accessibility.reporting-p1-li1-pre-link') }} <a href="mailto:{{ t('accessibility.contact-email-accessibility') }}">{{ t('accessibility.contact-email-accessibility') }}</a></li>
+            <li>{{ t('accessibility.reporting-p1-li1-pre-link') }} <a class="govuk-link" href="mailto:{{ t('accessibility.contact-email-accessibility') }}">{{ t('accessibility.contact-email-accessibility') }}</a></li>
         </ul>
         <p class="govuk-body">
-            <a href="http://www.w3.org/WAI/users/inaccessible">{{ t('accessibility.reporting-p2-link') }}</a>
+            <a class="govuk-link" href="http://www.w3.org/WAI/users/inaccessible">{{ t('accessibility.reporting-p2-link') }}</a>
         </p>
         <h2 class="govuk-heading-m">{{ t('accessibility.enforcement-header') }}</h2>
-        <p class="govuk-body">{{ t('accessibility.enforcement-p1-pre-link') }} <a href ="https://www.equalityadvisoryservice.com/">{{ t('accessibility.enforcement-p1-link') }}</a></p>
+        <p class="govuk-body">{{ t('accessibility.enforcement-p1-pre-link') }} <a class="govuk-link" href ="https://www.equalityadvisoryservice.com/">{{ t('accessibility.enforcement-p1-link') }}</a></p>
         <p class="govuk-body">{{ t('accessibility.enforcement-p2') }}</p>
         <h2 class="govuk-heading-m">{{ t('accessibility.technical-info-header') }}</h2>
         <p class="govuk-body">{{ t('accessibility.technical-info-p1') }}</p>

--- a/frontend/template-partials/views/error.html
+++ b/frontend/template-partials/views/error.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">{{ content.title }}</h1>
     <p>{{ content.message | safe }}</p>
-    <a href="" class="button" role="button">{{ t('buttons.try-again') }}</a>
+    <a href="" class="govuk-button" role="button">{{ t('buttons.try-again') }}</a>
 
     {% if showStack %}
       <pre>{{ error.stack }}</pre>

--- a/frontend/template-partials/views/terms.html
+++ b/frontend/template-partials/views/terms.html
@@ -5,28 +5,28 @@
 {% block propositionHeader %}{% endblock %}
 
 {% block mainContent %}
-  <h2>{{ how_we_use }}</h2>
+  <h2 class="govuk-heading-m">{{ how_we_use }}</h2>
 
   {% if data_link %}
     {% set ctx = data_link %}
     {% include "partials/external-link.html" %}
   {% endif %}
 
-  <p>{{ used_for }}</p>
+  <p class="govuk-body">{{ used_for }}</p>
 
   {% if used_for_list %}
   {{ bulletList(used_for_list.items) }}
   {% endif %}
 
-  <p>{{ your_info }}</p>
+  <p class="govuk-body">{{ your_info }}</p>
 
   {% if your_info_list %}
     {{ bulletList(your_info_list.items) }}
   {% endif %}
 
-  <p>{{ info_gathered }}</p>
+  <p class="govuk-body">{{ info_gathered }}</p>
 
-  <h2>{{ countries }}</h2>
+  <h2 class="govuk-heading-m">{{ countries }}</h2>
 
-  <p>{{ countries_text }}</p>
+  <p class="govuk-body">{{ countries_text }}</p>
 {% endblock %}

--- a/sandbox/assets/js/index.js
+++ b/sandbox/assets/js/index.js
@@ -3,68 +3,27 @@
 
 require('../../../frontend/themes/gov-uk/client-js');
 
-var $ = require('jquery');
-var typeahead = require('typeahead-aria');
-var Bloodhound = require('typeahead-aria').Bloodhound;
+const accessibleAutocomplete = require('accessible-autocomplete');
 
-typeahead.loadjQueryPlugin();
+function initTypeahead(element) {
+  const container = element.parentNode;
 
-$('.typeahead').each(function applyTypeahead() {
-  var $el = $(this);
-  var $parent = $el.parent();
-  var attributes = $el.prop('attributes');
-  var $input = $('<input/>');
-  var selectedValue = $el.val();
-  var typeaheadList = $el.find('option').map(function mapOptions() {
-    if (this.value === '') {
-      return undefined;
-    }
-    return this.value;
-  }).get();
-
-  // remove the selectbox
-  $el.remove();
-
-  $.each(attributes, function applyAttributes() {
-    $input.attr(this.name, this.value);
+  accessibleAutocomplete.enhanceSelectElement({
+    defaultValue: '',
+    selectElement: element
   });
 
-  $input.removeClass('js-hidden');
-  $input.addClass('form-control');
-  $input.val(selectedValue);
+  const input = container.querySelector('.autocomplete__input');
 
-  $parent.append($input);
+  function clear() {
+    element.value = '';
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }
 
-  $input.typeahead({
-    hint: false
-  }, {
-    source: new Bloodhound({
-      datumTokenizer: Bloodhound.tokenizers.whitespace,
-      queryTokenizer: Bloodhound.tokenizers.whitespace,
-      local: typeaheadList,
-      sorter: function sorter(a, b) {
-        var input = $input.val();
-        var startsWithInput = function startsWithInput(x) {
-          return x.toLowerCase().substr(0, input.length) === input.toLowerCase() ? -1 : 1;
-        };
-
-        var compareAlpha = function compareAlpha(x, y) {
-          var less = x < y ? -1 : 1;
-          return x === y ? 0 : less;
-        };
-
-        var compareStartsWithInput = function compareStartsWithInput(x, y) {
-          var startsWithFirst = startsWithInput(x);
-          var startsWithSecond = startsWithInput(y);
-
-          return startsWithFirst === startsWithSecond ? 0 : startsWithFirst;
-        };
-
-        var first = compareStartsWithInput(a, b);
-
-        return first === 0 ? compareAlpha(a, b) : first;
-      }
-    }),
-    limit: 100
+  // If user clears the field completely
+  input.addEventListener('input', () => {
+    if (!input.value) clear();
   });
-});
+}
+
+document.querySelectorAll('.typeahead').forEach(initTypeahead);

--- a/sandbox/assets/scss/app.scss
+++ b/sandbox/assets/scss/app.scss
@@ -2,26 +2,158 @@
 @import "../../../frontend/themes/gov-uk/styles/govuk";
 
 //autocomplete styling
-.tt-menu {
-    background-color: #fff;
-    border: 1px solid #ccc;
-    width: 65%;
-  }
-  
-.tt-suggestion {
-  padding: 0.5em;
-
-  &:hover,
-  &.tt-cursor {
-    color: #fff;
-    background-color: #0097cf;
-  }
-
-  &:hover {
-    cursor: pointer;
-  }
+.autocomplete__wrapper {
+  position: relative;
 }
 
-.twitter-typeahead {
+.autocomplete__hint,
+.autocomplete__input {
+  -webkit-appearance: none;
+  border: 2px solid #0b0c0c;
+  border-radius: 0;
+  /* Safari 10 on iOS adds implicit border rounding. */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  margin-bottom: 0;
+  /* BUG: Safari 10 on macOS seems to add an implicit margin. */
   width: 100%;
 }
+
+.autocomplete__input {
+  background-color: transparent;
+  position: relative;
+}
+
+.autocomplete__hint {
+  color: #b1b4b6;
+  position: absolute;
+}
+
+.autocomplete__input--default {
+  padding: 5px;
+}
+
+.govuk-form-group--error .autocomplete__input {
+  border: 2px solid #d4351c;
+}
+
+.autocomplete__input--focused {
+  outline: 3px solid #fd0;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 2px;
+}
+
+.autocomplete__input--show-all-values {
+  padding: 5px 34px 5px 5px;
+  /* Space for arrow. Other padding should match .autocomplete__input--default. */
+  cursor: pointer;
+}
+
+.autocomplete__wrapper > .govuk-select--error {
+  border-color: #d4351c !important;
+}
+
+.autocomplete__dropdown-arrow-down {
+  z-index: -1;
+  display: inline-block;
+  position: absolute;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  top: 10px;
+}
+
+.autocomplete__menu {
+  background-color: #fff;
+  border: 2px solid #0B0C0C;
+  border-top: 0;
+  color: #0B0C0C;
+  margin: 0;
+  max-height: 342px;
+  overflow-x: hidden;
+  padding: 0;
+  width: 100%;
+  width: calc(100% - 4px);
+}
+
+.autocomplete__menu--visible {
+  display: block;
+}
+
+.autocomplete__menu--hidden {
+  display: none;
+}
+
+.autocomplete__menu--overlay {
+  box-shadow: rgba(0, 0, 0, 0.256863) 0px 2px 6px;
+  left: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 100;
+}
+
+.autocomplete__menu--inline {
+  position: relative;
+  @extend .govuk-list
+}
+
+.autocomplete__option {
+  border-bottom: solid #b1b4b6;
+  border-width: 1px 0;
+  cursor: pointer;
+  display: block;
+  position: relative;
+}
+
+.autocomplete__option>* {
+  pointer-events: none;
+}
+
+.autocomplete__option:first-of-type {
+  border-top-width: 0;
+}
+
+.autocomplete__option:last-of-type {
+  border-bottom-width: 0;
+}
+
+.autocomplete__option--odd {
+  background-color: #FAFAFA;
+}
+
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  background-color: #1d70b8;
+  border-color: #1d70b8;
+  color: white;
+  outline: none;
+}
+
+.autocomplete__option--no-results {
+  background-color: #FAFAFA;
+  color: #646b6f;
+  cursor: not-allowed;
+}
+
+.autocomplete__hint,
+.autocomplete__input,
+.autocomplete__option {
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.autocomplete__hint,
+.autocomplete__option {
+  padding: 5px;
+}
+
+@media (min-width: 641px) {
+  .autocomplete__hint,
+  .autocomplete__input,
+  .autocomplete__option {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -8,17 +8,17 @@
   },
   "scripts": {
     "start": "node server.js",
-    "start:dev": "[ -f .env ] && HOF_SANDBOX=true .../bin/hof-build watch --env || HOF_SANDBOX=true ../bin/hof-build watch",
+    "start:dev": "HOF_SANDBOX=true .../bin/hof-build watch --env || HOF_SANDBOX=true ../bin/hof-build watch",
     "dev": "yarn && GA_TAG=test nodemon server",
     "build": "HOF_SANDBOX=true ../bin/hof-build",
     "postinstall": "yarn run build"
   },
   "author": "",
   "dependencies": {
+    "accessible-autocomplete": "^3.0.1",
     "govuk-frontend": "4.10",
     "jquery": "^3.7.1",
-    "sass": "^1.53.0",
-    "typeahead-aria": "^1.0.4"
+    "sass": "^1.53.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.15"

--- a/sandbox/yarn.lock
+++ b/sandbox/yarn.lock
@@ -91,6 +91,11 @@
     "@parcel/watcher-win32-ia32" "2.5.6"
     "@parcel/watcher-win32-x64" "2.5.6"
 
+accessible-autocomplete@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz#8ddf4934d0b4ba6acb28de486dd505e062cdc86e"
+  integrity sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==
+
 anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -226,11 +231,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-jquery@>=1.11:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-4.0.0.tgz#95c33ac29005ff72ec444c5ba1cf457e61404fbb"
-  integrity sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==
-
 jquery@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
@@ -352,13 +352,6 @@ touch@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.1.tgz#097a23d7b161476435e5c1344a95c0f75b4a5694"
   integrity sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==
-
-typeahead-aria@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/typeahead-aria/-/typeahead-aria-1.0.4.tgz#d2829cc01c0226a367627f3098a468c4e0343f00"
-  integrity sha512-6g0XtcM1AiPMlyXOuAb90Lg0WGi9PdbH68La7kUJmZwxUdpE80IC6tewBg0a/ug1Betoz1xCfEqTgkhuN6wo4w==
-  dependencies:
-    jquery ">=1.11"
 
 undefsafe@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
## What? 
Bug fixes and improvements for nunjucks refactoring
## Why? 
part of nunjucks refactoring work
- the typeahead-aria package used in the sandbox is outdated and now causes a bug  that does not stops the dropdown list in select fields. the accessible -autocomplete package is managed by alphagov (same as govuk design system) and is used across several of our services so I have replaced it in the sandbox
## How? 
- fixed bug where legend class for radio and checkbox groups show as 'undefined' in html if not set
- added govuk classes to elements in accessibility.html, terms.html and error.html
- in template-mixins.js maded disabled option true only if set to true or 'true'

- sandbox changes:
  - fixed .env file not being picked up on start:dev command
  -  added accessible-autocomplete and remove outdated typeahead-aria package for dropdown select fields
  - added accessible autocomplete javascript
  - added accessible autocomplete css

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch - n/a
- [ ] I have created a JIRA number for my commit - n/a
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
