### PR TITLE
HOFF-2035: Nunjucks Refactoring(Checkbox Mixin)

### DIFF
--- a/frontend/template-mixins/partials/forms/checkbox.html
+++ b/frontend/template-mixins/partials/forms/checkbox.html
@@ -1,20 +1,30 @@
-<div id="{{key}}-group" class="govuk-form-group {{#compound}} form-group-compound{{/compound}}{{#formGroupClassName}} {{formGroupClassName}}{{/formGroupClassName}}{{#error}} govuk-form-group--error{{/error}}">
-    {{#error}}
-    <p id="{{key}}-error" class="govuk-error-message" aria-hidden="true">
-        <span class="govuk-visually-hidden">Error:</span> {{error.message}}
-    </p>
-    {{/error}}
+<div id="{{ key }}-group"
+  class="govuk-form-group {% if compound %} form-group-compound{% endif %}{% if formGroupClassName %} {{ formGroupClassName }}{% endif %}{% if error %} govuk-form-group--error{% endif %}">
+  {% if error %}
+  <p id="{{ key }}-error" class="govuk-error-message" aria-hidden="true">
+    <span class="govuk-visually-hidden">Error:</span> {{ error.message }}
+  </p>
+  {% endif %}
+  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
     <div class="govuk-checkboxes__item">
-        <input class="govuk-checkboxes__input" type="checkbox" id="{{key}}" name="{{key}}" value="true" aria-required="{{required}}"{{#error}} aria-invalid="true"{{/error}}{{^error}}{{#toggle}} data-toggle="{{toggle}}"{{/toggle}}{{#selected}} checked="checked"{{/selected}}{{/error}}>
-        <label for="{{key}}" class="{{#className}}{{className}} {{/className}}{{#invalid}}invalid-input{{/invalid}}">
-            {{{label}}}
-            {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
-        </label>
-        {{#hint}}
-        <div id="{{key}}-hint" class="govuk-hint govuk-checkboxes__hint">
-          {{{hint}}}
-        </div>
-        {{/hint}}
+      <input class="govuk-checkboxes__input" type="checkbox" id="{{ key }}" name="{{ key }}" value="true"
+        aria-required="{{ required }}" {% if error %} aria-invalid="true" {% endif %}{% if toggle %}
+        aria-controls="conditional-{{ key }}" {% endif %}{% if selected %} checked="checked" {% endif %}>
+      <label for="{{ key }}"
+        class="{% if className %}{{ className }} {% endif %}{% if invalid %}invalid-input{% endif %}">
+        {{ label | safe }}
+        {% if error %}<span class="visuallyhidden">{{ error.message }}</span>{% endif %}
+      </label>
+      {% if hint %}
+      <div id="{{ key }}-hint" class="govuk-hint govuk-checkboxes__hint">
+        {{ hint | safe }}
+      </div>
+      {% endif %}
     </div>
-    {{#renderChild}}{{/renderChild}}
+    {% if toggle %}
+    <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional-{{ key }}">
+      {{ renderChild({ toggle: toggle, child: child }) | safe }}
+    </div>
+    {% endif %}
+  </div>
 </div>

--- a/frontend/template-partials/views/confirm.html
+++ b/frontend/template-partials/views/confirm.html
@@ -2,7 +2,7 @@
 
 {% from "partials/summary-table.html" import summaryTableComponent %}
 
-{% block page_content %}
+{% block pageContent %}
   {% for row in rows %}
     {{ summaryTableComponent(row, t, baseUrl) }}
   {% endfor %}

--- a/frontend/template-partials/views/partials/page.html
+++ b/frontend/template-partials/views/partials/page.html
@@ -12,7 +12,7 @@
 
 {% block mainContent %}
   {% call form(encoding=encoding, intro=intro, csrf_token) %}
-    {% block page_content %}{% endblock %}
+    {% block pageContent %}{% endblock %}
   {% endcall %}
   {% include "partials/session-timeout-warning.html" %}
 {% endblock %}

--- a/frontend/template-partials/views/step.html
+++ b/frontend/template-partials/views/step.html
@@ -1,6 +1,6 @@
 {% extends "partials/page.html" %}
 
-{% block page_content %}
+{% block pageContent %}
   {% block beforeFields %}
     {% if beforeFields is defined %}
       {{ beforeFields | safe }}

--- a/sandbox/apps/sandbox/views/form-guidance-link.html
+++ b/sandbox/apps/sandbox/views/form-guidance-link.html
@@ -1,6 +1,6 @@
 {% extends "partials/page.html" %}
 
-{% block page_content %}
+{% block pageContent %}
   <h2>{{ t('pages.build-your-own-form.subheader') }}</h2>
   <a class="govuk-link" href="https://ukhomeofficeforms.github.io/hof-guide/documentation/#building-your-first-hof-form">Link to HOF form guidance</a>
 {% endblock %}

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -1246,56 +1246,64 @@ describe('Template Mixins', () => {
     });
 
     describe('checkbox', () => {
-      beforeEach(() => {
-      });
-
       it('adds a function to res.locals', () => {
         middleware(req, res, next);
-        res.locals.checkbox.should.be.a('function');
+        expect(typeof res.locals.checkbox).toBe('function');
       });
 
-      it('returns a function', () => {
+      it('returns an object', () => {
         middleware(req, res, next);
-        res.locals.checkbox().should.be.a('function');
+        expect(typeof res.locals.checkbox()).toBe('object');
       });
 
       it('looks up field label', () => {
         middleware(req, res, next);
-        res.locals.checkbox().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          label: 'fields.field-name.label'
-        }));
+        res.locals.checkbox('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            label: 'fields.field-name.label'
+          }));
       });
 
       it('prefixes translation lookup with namespace if provided', () => {
         middleware = mixins({ sharedTranslationsKey: 'name.space' });
         middleware(req, res, next);
-        res.locals.checkbox().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          label: 'name.space.fields.field-name.label'
-        }));
+        res.locals.checkbox('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            label: 'name.space.fields.field-name.label'
+          }));
       });
 
       it('uses locales translation property', () => {
-        req.translate = sinon.stub().withArgs('field-name.label').returns('Field name');
+        req.translate = jest.fn().mockImplementation(key => {
+          if (key === 'field-name.label') return 'Field name';
+          return undefined;
+        });
         res.locals.options.fields = {
           'field-name': {
             label: 'field-name.label'
           }
         };
         middleware(req, res, next);
-        res.locals.checkbox().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          label: 'Field name'
-        }));
+        res.locals.checkbox('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            label: 'Field name'
+          }));
       });
 
       it('should default className `govuk-label govuk-checkboxes__label`', () => {
         middleware(req, res, next);
-        res.locals.checkbox().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          className: 'govuk-label govuk-checkboxes__label'
-        }));
+        res.locals.checkbox('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            className: 'govuk-label govuk-checkboxes__label'
+          }));
       });
 
       it('should override default className if one was specified against the field', () => {
@@ -1305,10 +1313,12 @@ describe('Template Mixins', () => {
           }
         };
         middleware(req, res, next);
-        res.locals.checkbox().call(res.locals, 'field-name');
-        render.should.have.been.calledWith(sinon.match({
-          className: 'overwritten'
-        }));
+        res.locals.checkbox('field-name');
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            className: 'overwritten'
+          }));
       });
     });
 
@@ -2278,8 +2288,8 @@ describe('Template Mixins', () => {
 
     describe('checkbox renderChild', () => {
       beforeEach(() => {
-        middleware = mixins({ 'field-name': {} });
         middleware(req, res, next);
+        options = [{}];
         res.locals.checkbox('field-name');
         renderChild = renderSpy.lastContext.renderChild;
       });
@@ -2305,18 +2315,15 @@ describe('Template Mixins', () => {
           };
 
           renderChild = renderSpy.lastContext.renderChild;
+          jest.restoreAllMocks();
         });
 
         it('accepts an HTML template string', () => {
           options.child = '<div>{{ key }}</div>';
           options.key = 'value';
 
-          const output = res.locals.nunjucksEnv.renderString(
-            options.child,
-            options
-          );
-
-          expect(renderChild(options)).toBe(output);
+          const result = renderChild(options);
+          expect(result).toBe('<div>value</div>');
         });
 
         it('accepts a custom partial', () => {


### PR DESCRIPTION
## What? 
[HOFF-2035](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2035) -  Nunjucks Refactoring (Checkbox Mixin)
## Why? 
part of nunjucks refactoring work
## How? 
- amend checkbox.html to use nunjucks templating
- refactor checkbox unit tests
## Testing?
tested locally in sandbox and coa
## Screenshots (optional)
## Anything Else? (optional)
- changed blocks with the name page_content to camelCase for consistency with other blocks
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
