### PR TITLE
HOFF-2031: Nunjucks Refactoring (Input Date Mixin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1738,7 +1738,7 @@ currency
 select
 inputText
 inputFile
-input-date
+inputDate
 input-amount-with-unit-select
 inputTextCompound
 inputTextCode

--- a/components/date/templates/date.html
+++ b/components/date/templates/date.html
@@ -1,20 +1,34 @@
-<div class="govuk-form-group {{#error}}govuk-form-group--error{{/error}}">
-<fieldset id="{{key}}-group" class="govuk-fieldset{{#className}} {{className}}{{/className}}" role="group">
-  <legend class="govuk-fieldset__legend {{#isPageHeading}}govuk-fieldset__legend--l{{/isPageHeading}}{{#legendClassName}} {{legendClassName}}{{/legendClassName}}">
-    {{#isPageHeading}}<h1 class="govuk-fieldset__heading">{{/isPageHeading}}
-      {{legend}}
-    {{#isPageHeading}}</h1>{{/isPageHeading}}
-  </legend>
-    {{#hint}}
-      <div id="{{key}}-hint" class="govuk-hint">{{{hint}}}</div>
-    {{/hint}}
-    {{#error}}
-      <p id="{{key}}-error" class="govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span> {{error.message}}
-      </p>
-    {{/error}}
-  <div id="{{key}}" class="govuk-date-input">
-    {{#input-date}}{{key}}{{/input-date}}
-  </div>
-</fieldset>
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{% set legendClasses = "" %}
+{% set classes = className or "" %}
+{% set legendClasses = legendClasses + "govuk-fieldset__legend--l " if isPageHeading %}
+
+<div class="govuk-form-group{% if error %} govuk-form-group--error{% endif %}">
+  {% call govukFieldset({
+    attributes: { id: key + "-group" },
+    role: "group",
+    legend: {
+      html: legend | safe,
+      classes: legendClasses + (legendClassName if legendClassName),
+      isPageHeading: isPageHeading
+    },
+
+    classes: classes
+  }) %}
+
+  {% if hint %}
+    <div id="{{ key }}-hint" class="govuk-hint">
+      {{ hint | safe }}
+    </div>
+  {% endif %}
+  {% if error %}
+    <p id="{{ key }}-error" class="govuk-error-message">
+      <span class="govuk-visually-hidden">Error:</span> {{ error.message }}
+    </p>
+  {% endif %}
+    <div id="{{ key }}" class="govuk-date-input">
+      {{ inputDate(key) }}
+    </div>
+  {% endcall %}
 </div>

--- a/controller/controller.js
+++ b/controller/controller.js
@@ -220,7 +220,7 @@ module.exports = class Controller extends BaseController {
               req.form.errors[key].errorLinkId = key + '-' + field.options[0];
             }
             // eslint-disable-next-line brace-style
-          } else if (field && field.mixin === 'input-date') {
+          } else if (field && field.mixin === 'inputDate') {
             // get first field for date input control
             req.form.errors[key].errorLinkId = key + '-day';
           } else if (field && field.mixin === 'input-amount-with-unit-select') {

--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -598,49 +598,59 @@ module.exports = function (options) {
           );
         }
       },
-      'input-date': {
-        handler: function () {
-          /**
-          * props: '[value] [id]'
-          */
-          return function (key) {
-            const field = Object.assign({}, this.options.fields[key] || options.fields[key]);
-            key = nunjucksRender(key, this);
-            // Exact unless there is a inexact property against the fields key.
-            const isExact = field.inexact !== true;
+      inputDate: {
+        handler: function (key) {
+          const fieldsConfig =
+            this.options?.fields ||
+            this.fields ||
+            options?.fields ||
+            {};
+          const field = fieldsConfig[key] || {};
 
-            let autocomplete = field.autocomplete || {};
-            if (autocomplete === 'off') {
-              autocomplete = {
-                day: 'off',
-                month: 'off',
-                year: 'off'
-              };
-            } else if (typeof autocomplete === 'string') {
-              autocomplete = {
-                day: autocomplete + '-day',
-                month: autocomplete + '-month',
-                year: autocomplete + '-year'
-              };
-            }
-            const isThisRequired = field.validate ? field.validate.indexOf('required') > -1 : false;
-            const formGroupClassName = (field.formGroup && field.formGroup.className) ? field.formGroup.className : '';
-            const classNameDay = (field.controlsClass && field.controlsClass.day) ? field.controlsClass.day : 'govuk-date-input__input govuk-input--width-2';
-            const classNameMonth = (field.controlsClass && field.controlsClass.month) ? field.controlsClass.month : 'govuk-date-input__input govuk-input--width-2';
-            const classNameYear = (field.controlsClass && field.controlsClass.year) ? field.controlsClass.year : 'govuk-date-input__input govuk-input--width-4';
+          // Exact unless there is a inexact property against the fields key.
+          const isExact = field.inexact !== true;
+          const values = this.values || {};
+          const errors = this.errors || {};
+          const child = suffix => fieldsConfig[`${key}-${suffix}`] || {};
 
-            const parts = [];
-
-            if (isExact) {
-              const dayPart = nunjucksEnv.renderString(compiled['partials/forms/input-text-date'], inputText.call(this, key + '-day', { inputmode: 'numeric', min: 1, max: 31, maxlength: 2, hintId: key + '-hint', date: true, autocomplete: autocomplete.day, formGroupClassName, className: classNameDay, isThisRequired }));
-              parts.push(dayPart);
-            }
-
-            const monthPart = nunjucksEnv.renderString(compiled['partials/forms/input-text-date'], inputText.call(this, key + '-month', { inputmode: 'numeric', min: 1, max: 12, maxlength: 2, hintId: key + '-hint', date: true, autocomplete: autocomplete.month, formGroupClassName, className: classNameMonth, isThisRequired }));
-            const yearPart = nunjucksEnv.renderString(compiled['partials/forms/input-text-date'], inputText.call(this, key + '-year', { inputmode: 'numeric', maxlength: 4, hintId: key + '-hint', date: true, autocomplete: autocomplete.year, formGroupClassName, className: classNameYear, isThisRequired }));
-
-            return parts.concat(monthPart, yearPart).join('\n');
+          const autocomplete = {
+            day: child('day').autocomplete || 'off',
+            month: child('month').autocomplete || 'off',
+            year: child('year').autocomplete || 'off'
           };
+          const value = suffix => values?.[`${key}-${suffix}`];
+          const error = errors?.[key];
+          const dayValue = isExact ? value('day') : undefined;
+          const inputClassNames = {
+            day: 'govuk-input--width-2',
+            month: 'govuk-input--width-2',
+            year: 'govuk-input--width-4'
+          };
+          const buildField = suffix => ({
+            id: `${key}-${suffix}`,
+            label: this.t(child(suffix).label),
+            value: suffix === 'day' ? dayValue : value(suffix),
+            className: field.controlsClass?.[suffix] || inputClassNames[suffix] || ''
+          });
+          const fields = {
+            day: buildField('day'),
+            month: buildField('month'),
+            year: buildField('year')
+          };
+          const context = {
+            date: true,
+            formGroupClassName: (field.formGroup && field.formGroup.className) ? field.formGroup.className : '',
+            labelClassName: field.labelClassName,
+            error,
+            autocomplete,
+            ...fields
+          };
+
+          return new nunjucks.runtime.SafeString(
+            nunjucksEnv.renderString(compiled['partials/forms/input-text-date'], {
+              ...context
+            })
+          );
         }
       },
       'input-amount-with-unit-select': {
@@ -689,39 +699,36 @@ module.exports = function (options) {
       }
     };
     Object.entries(mixins || {}).forEach(([name, mixin]) => {
-      if (typeof mixin.handler === 'function') {
-        res.locals[name] = mixin.handler.bind(res.locals);
-        return;
-      }
+      const handler = typeof mixin.handler === 'function'
+        ? mixin.handler : function (key) {
+          // for mixins with renderWith
+          const ctxThis = this || res.locals;   // ensure context
+          ctxThis.options = ctxThis.options || {};
+          ctxThis.options.fields = ctxThis.options.fields || {};
 
-      // for mixins with renderWith
-      res.locals[name] = function (key) {
-        const ctxThis = this || res.locals;   // ensure context
-        ctxThis.options = ctxThis.options || {};
-        ctxThis.options.fields = ctxThis.options.fields || {};
+          key = nunjucksRender(key, ctxThis);
 
-        key = nunjucksRender(key, ctxThis);
-
-        const rendered = mixin.renderWith.call(
-          ctxThis,
-          key,
-          typeof mixin.options === 'function' ? mixin.options.call(ctxThis, key) : mixin.options
-        );
-        const ctx = Object.assign({}, res.locals, rendered);
-        // try to render by template name first so relative imports/includes resolve via loader roots
-        const viewExt = (options && options.viewEngine) ? '.' + options.viewEngine : '.html';
-        const templateName = mixin.path + viewExt;
-        try {
-          return new nunjucks.runtime.SafeString(
-            nunjucksEnv.render(templateName, ctx)
+          const rendered = mixin.renderWith.call(
+            ctxThis,
+            key,
+            typeof mixin.options === 'function' ? mixin.options.call(ctxThis, key) : mixin.options
           );
-        } catch (err) {
-          // fallback to rendering the compiled string (older behaviour)
-          return new nunjucks.runtime.SafeString(
-            nunjucksEnv.renderString(compiled[mixin.path], ctx)
-          );
-        }
-      }.bind(res.locals);
+          const ctx = Object.assign({}, res.locals, rendered);
+          // try to render by template name first so relative imports/includes resolve via loader roots
+          const viewExt = (options && options.viewEngine) ? '.' + options.viewEngine : '.html';
+          const templateName = mixin.path + viewExt;
+          try {
+            return new nunjucks.runtime.SafeString(
+              nunjucksEnv.render(templateName, ctx)
+            );
+          } catch (err) {
+            // fallback to rendering the compiled string (older behaviour)
+            return new nunjucks.runtime.SafeString(
+              nunjucksEnv.renderString(compiled[mixin.path], ctx)
+            );
+          }
+        };
+      res.locals[name] = handler.bind(res.locals);
     });
 
     function renderFieldImpl(key) {
@@ -784,7 +791,19 @@ module.exports = function (options) {
       }
 
       // direct call
-      return renderFieldImpl.call(this, arguments[0]);
+      const result = renderFieldImpl.call(this, arguments[0]);
+      // preserve pre rendered HTML and already wrapped template mixins
+      if (
+        result === null ||
+        result instanceof nunjucks.runtime.SafeString
+      ) {
+        return result;
+      }
+      // wrap plain strings coming from template mixins
+      if (typeof result === 'string') {
+        return new nunjucks.runtime.SafeString(result);
+      }
+      return result;
     };
 
     next();

--- a/frontend/template-mixins/partials/forms/input-text-date.html
+++ b/frontend/template-mixins/partials/forms/input-text-date.html
@@ -1,38 +1,104 @@
-<div class="govuk-date-input__item">
-    <div id="{{id}}-group" class="{{#formGroupClassName}} {{formGroupClassName}}{{/formGroupClassName}}">
-      <label for="{{id}}" class="{{labelClassName}}">
-          <span class="label-text">{{{label}}}</span>
-      </label>
-      {{#hint}}<div {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{{hint}}}</div>{{/hint}}
-      {{#renderChild}}{{/renderChild}}
-          {{#attributes}}
-              {{#prefix}}
-                  <div class="govuk-input__prefix" aria-hidden="true">{{prefix}}</div>
-              {{/prefix}}
-          {{/attributes}}
-          <input
-              type="{{type}}"
-              name="{{id}}"
-              id="{{id}}"
-              class="govuk-input{{#className}} {{className}}{{/className}}{{#error}} govuk-input--error{{/error}}"
-              aria-required="{{required}}"
-              {{#value}} value="{{value}}"{{/value}}
-              {{#min}} min="{{min}}"{{/min}}
-              {{#max}} max="{{max}}"{{/max}}
-              {{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}
-              {{#pattern}} pattern="{{pattern}}"{{/pattern}}
-              {{#inputmode}}inputmode="{{inputmode}}"{{/inputmode}}
-              {{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}
-              {{#error}} aria-invalid="true"{{/error}}
-              {{#autocomplete}} autocomplete="{{autocomplete}}"{{/autocomplete}}
-              {{#attributes}}
-                  {{attribute}}="{{value}}"
-              {{/attributes}}
-          >
-          {{#attributes}}
-              {{#suffix}}
-                  <div class="govuk-input__prefix" aria-hidden="true">{{suffix}}</div>
-              {{/suffix}}
-          {{/attributes}}
-    </div>
-</div>
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+
+{#-------------------------------------------#}
+{#  Set form group and legend classes        #}
+{#-------------------------------------------#}
+{% set formGroupClasses = "" %}
+{% set legendClasses = "" %}
+{% set classes = "" %}
+{% set formGroupClasses = formGroupClasses + formGroupClassName if formGroupClassName %}
+{% set legendClasses = legendClasses + "govuk-fieldset__legend--l " if isPageHeading %}
+{% set classes = classes + " govuk-input--error" if error %}
+
+{#------------------------------------------#}
+{#  Set hint object if hint exists          #}
+{#------------------------------------------#}
+{% set hintObj = null %}
+{% if hint %}
+  {% set hintObj = {
+    html: hint | safe,
+    classes: "govuk-hint",
+    id: hintId
+  } %}
+{% endif %}
+
+{#------------------------------------------#}
+{#  Set error object if error exists        #}
+{#------------------------------------------#}
+
+{% set errorObj = null %}
+{% if error %}
+  {% set errorObj = {
+    text: error.message
+  } %}
+{% endif %}
+
+{#----------------------------------------------#}
+
+{#  Set beforeInput HTML from renderChild()     #}
+
+{#----------------------------------------------#}
+
+{% if renderChild is defined %}
+  {% set beforeInputObj = { html: renderChild({}) | safe } %}
+{% else %}
+  {% set beforeInputObj = undefined %}
+{% endif %}
+
+{{ govukDateInput({
+  id: id,
+  namePrefix: id,
+  formGroup: {
+    classes: formGroupClasses,
+    beforeInput: beforeInputObj
+
+  },
+  classes: classes,
+  fieldset: {
+    legend: {
+      text: legend,
+      classes: legendClasses + (legendClassName if legendClassName)
+    }
+  },
+  hint: hintObj,
+  items: [
+    {
+      id: day.id,
+      name: day.id,
+      label: day.label,
+      classes: day.className + classes,
+      value: day.value,
+      attributes: {
+        autocomplete: autocomplete.day,
+        min: 1,
+        max: 12,
+        maxlength: 2
+      }
+    },
+    {
+      id: month.id,
+      name: month.id,
+      label: month.label,
+      classes: month.className + classes,
+      value: month.value,
+      attributes: {
+        autocomplete: autocomplete.month,
+        min: 1,
+        max: 12,
+        maxlength: 2
+      }
+    },
+    {
+      id: year.id,
+      name: year.id,
+      label: year.label,
+      classes: year.className + classes,
+      value: year.value,
+      attributes: {
+        autocomplete: autocomplete.year,
+        maxlength: 4
+      }
+    }
+  ]
+}) }}
+

--- a/frontend/template-mixins/partials/forms/option-group.html
+++ b/frontend/template-mixins/partials/forms/option-group.html
@@ -95,7 +95,7 @@
   },
   fieldset: {
     legend: {
-      html: legend,
+      html: legend | safe,
       isPageHeading: isPageHeading,
       classes: legendClasses + (legendClassName if legendClassName)
     }
@@ -108,7 +108,7 @@
   items: items
 } %}
 
-{%if isWarning %}
+{% if isWarning %}
   <div class="govuk-form-group{% if errorObj %} govuk-form-group--error{% endif %} {{ formGroupClasses }}">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend {{ legendClasses }}">

--- a/frontend/template-partials/views/cookies.html
+++ b/frontend/template-partials/views/cookies.html
@@ -18,7 +18,7 @@
   {% block mainContent %}
     <p class="govuk-body">{{ intro }}</p>
     {% if not hasGoogleAnalytics %}
-      {%if intro_list %}
+      {% if intro_list %}
         {{ bulletList(intro_list.items) }}
       {% endif %}
       {% if indent_intro %}

--- a/frontend/themes/gov-uk/styles/_typography.scss
+++ b/frontend/themes/gov-uk/styles/_typography.scss
@@ -24,7 +24,7 @@ h3:not(.govuk-heading-s) {
   margin-bottom: govuk-spacing(2);
 }
 
-p:not(.govuk-body) {
+p {
   @include govuk-font($size: 19);
   margin-top: 0;
   margin-bottom: govuk-spacing(4);

--- a/sandbox/apps/sandbox/fields.js
+++ b/sandbox/apps/sandbox/fields.js
@@ -19,7 +19,7 @@ module.exports = {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'dateOfBirth': dateComponent('dateOfBirth', {
-    mixin: 'input-date',
+    mixin: 'inputDate',
     isPageHeading: 'true',
     validate: [
       'required',

--- a/sandbox/assets/scss/app.scss
+++ b/sandbox/assets/scss/app.scss
@@ -35,7 +35,7 @@
 }
 
 .govuk-form-group--error .autocomplete__input {
-  border: 2px solid #d4351c;
+  border: 2px solid govuk-functional-colour(error);
 }
 
 .autocomplete__input--focused {
@@ -51,7 +51,7 @@
 }
 
 .autocomplete__wrapper > .govuk-select--error {
-  border-color: #d4351c !important;
+  border-color: govuk-functional-colour(error) !important;
 }
 
 .autocomplete__dropdown-arrow-down {

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -462,139 +462,97 @@ describe('Template Mixins', () => {
       });
     });
 
-    describe('input-date', () => {
+    describe('inputDate', () => {
       it('adds a function to res.locals', () => {
         middleware(req, res, next);
-        res.locals['input-date'].should.be.a('function');
+        expect(typeof res.locals.inputDate).toBe('function');
       });
 
-      it('returns a function', () => {
+      it('returns an object', () => {
         middleware(req, res, next);
-        res.locals['input-date']().should.be.a('function');
+        expect(typeof res.locals.inputDate()).toBe('object');
       });
 
-      it('renders 7 times if the field is not marked as inexact', () => {
-        middleware(req, res, next);
-        res.locals['input-date']().call(res.locals, 'field-name');
-        render.callCount.should.be.equal(7);
-      });
-
-      it('renders 5 times if the field is marked as inexact', () => {
+      it('looks up field labels', () => {
         res.locals.options.fields = {
-          'field-name': {
-            inexact: true
+          'field-name-day': {
+            label: 'fields.field-name-day.label'
+          },
+          'field-name-month': {
+            label: 'fields.field-name-month.label'
+          },
+          'field-name-year': {
+            label: 'fields.field-name-year.label'
           }
         };
+
         middleware(req, res, next);
-        res.locals['input-date']().call(res.locals, 'field-name');
-        render.callCount.should.be.equal(5);
-      });
+        res.locals.inputDate('field-name');
 
-      it('looks up field label', () => {
-        middleware(req, res, next);
-        res.locals['input-date']().call(res.locals, 'field-name');
+        const dayLabel = renderSpy.mock.calls[0][1].options.fields['field-name-day'];
+        const monthLabel = renderSpy.mock.calls[0][1].options.fields['field-name-month'];
+        const yearLabel = renderSpy.mock.calls[0][1].options.fields['field-name-year'];
 
-        render.called;
-
-        const dayCall = render.getCall(2);
-        const monthCall = render.getCall(4);
-        const yearCall = render.getCall(6);
-
-        dayCall.should.have.been.calledWith(sinon.match({
+        expect(dayLabel).toEqual(expect.objectContaining({
           label: 'fields.field-name-day.label'
         }));
 
-        monthCall.should.have.been.calledWith(sinon.match({
+        expect(monthLabel).toEqual(expect.objectContaining({
           label: 'fields.field-name-month.label'
         }));
 
-        yearCall.should.have.been.calledWith(sinon.match({
+        expect(yearLabel).toEqual(expect.objectContaining({
           label: 'fields.field-name-year.label'
-        }));
-      });
-
-      it('govuk-form-group class is set in the date fields by default', () => {
-        middleware(req, res, next);
-        res.locals['input-date']().call(res.locals, 'field-name');
-
-        render.called;
-
-        const dayCall = render.getCall(2);
-        const monthCall = render.getCall(4);
-        const yearCall = render.getCall(6);
-
-        dayCall.should.have.been.calledWith(sinon.match({
-          formGroupClassName: 'govuk-form-group'
-        }));
-
-        monthCall.should.have.been.calledWith(sinon.match({
-          formGroupClassName: 'govuk-form-group'
-        }));
-
-        yearCall.should.have.been.calledWith(sinon.match({
-          formGroupClassName: 'govuk-form-group'
         }));
       });
 
       describe('autocomplete', () => {
         it('should have a suffix of -day -month and -year', () => {
           res.locals.options.fields = {
-            'field-name': {
-              autocomplete: 'bday'
+            'field-name-day': {
+              autocomplete: 'bday-day'
+            },
+            'field-name-month': {
+              autocomplete: 'bday-month'
+            },
+            'field-name-year': {
+              autocomplete: 'bday-year'
             }
           };
           middleware(req, res, next);
-          res.locals['input-date']().call(res.locals, 'field-name');
+          res.locals.inputDate('field-name');
 
-          render.should.have.been.called;
+          const context = renderSpy.mock.calls[0][1];
 
-          const dayCall = render.getCall(2);
-          const monthCall = render.getCall(4);
-          const yearCall = render.getCall(6);
-
-          dayCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'bday-day'
-          }));
-
-          monthCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'bday-month'
-          }));
-
-          yearCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'bday-year'
-          }));
+          expect(context.autocomplete).toEqual({
+            day: 'bday-day',
+            month: 'bday-month',
+            year: 'bday-year'
+          });
         });
 
         it('should be set as exact values if an object is given', () => {
           res.locals.options.fields = {
-            'field-name': {
-              autocomplete: {
-                day: 'day-type',
-                month: 'month-type',
-                year: 'year-type'
-              }
+            'field-name-day': {
+              autocomplete: 'day-type'
+            },
+            'field-name-month': {
+              autocomplete: 'month-type'
+            },
+            'field-name-year': {
+              autocomplete: 'year-type'
             }
           };
           middleware(req, res, next);
-          res.locals['input-date']().call(res.locals, 'field-name');
+          res.locals.inputDate('field-name');
 
-          render.called;
+          const context = renderSpy.mock.calls[0][1];
 
-          const dayCall = render.getCall(2);
-          const monthCall = render.getCall(4);
-          const yearCall = render.getCall(6);
-
-          dayCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'day-type'
-          }));
-
-          monthCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'month-type'
-          }));
-
-          yearCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'year-type'
-          }));
+          expect(context.autocomplete).toEqual({
+            day: 'day-type',
+            month: 'month-type',
+            year: 'year-type'
+          });
         });
 
         it('should set autocomplete to off if off is specified', () => {
@@ -604,86 +562,71 @@ describe('Template Mixins', () => {
             }
           };
           middleware(req, res, next);
-          res.locals['input-date']().call(res.locals, 'field-name');
+          res.locals.inputDate('field-name');
 
-          render.called;
+          const context = renderSpy.mock.calls[0][1];
 
-          const dayCall = render.getCall(2);
-          const monthCall = render.getCall(4);
-          const yearCall = render.getCall(6);
-
-          dayCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'off'
-          }));
-
-          monthCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'off'
-          }));
-
-          yearCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'off'
-          }));
+          expect(context.autocomplete).toEqual({
+            day: 'off',
+            month: 'off',
+            year: 'off'
+          });
         });
 
-        it('should default to no attribute across all date fields', () => {
+        it('should default to off when not provided', () => {
           middleware(req, res, next);
-          res.locals['input-date']().call(res.locals, 'field-name');
+          res.locals.inputDate('field-name');
 
-          render.called;
+          const context = renderSpy.mock.calls[0][1];
 
-          const dayCall = render.getCall(0);
-          const monthCall = render.getCall(1);
-          const yearCall = render.getCall(2);
-
-          dayCall.should.have.been.calledWith(sinon.match({
-            autocomplete: undefined
-          }));
-
-          monthCall.should.have.been.calledWith(sinon.match({
-            autocomplete: undefined
-          }));
-
-          yearCall.should.have.been.calledWith(sinon.match({
-            autocomplete: undefined
-          }));
+          expect(context.autocomplete).toEqual({
+            day: 'off',
+            month: 'off',
+            year: 'off'
+          });
         });
       });
 
       it('prefixes translation lookup with namespace if provided', () => {
+        res.locals.options.fields =
+        {
+          'field-name-day': {
+            label: 'fields.field-name-day.label'
+          },
+          'field-name-month': {
+            label: 'fields.field-name-month.label'
+          },
+          'field-name-year': {
+            label: 'fields.field-name-year.label'
+          }
+        };
         middleware = mixins({ sharedTranslationsKey: 'name.space' });
         middleware(req, res, next);
-        res.locals['input-date']().call(res.locals, 'field-name');
 
-        render.called;
+        res.locals.inputDate('field-name');
 
-        const dayCall = render.getCall(2);
-        const monthCall = render.getCall(4);
-        const yearCall = render.getCall(6);
+        const context = renderSpy.mock.calls[renderSpy.mock.calls.length - 1][1];
 
-        dayCall.should.have.been.calledWith(sinon.match({
-          label: 'name.space.fields.field-name-day.label'
-        }));
-
-        monthCall.should.have.been.calledWith(sinon.match({
-          label: 'name.space.fields.field-name-month.label'
-        }));
-
-        yearCall.should.have.been.calledWith(sinon.match({
-          label: 'name.space.fields.field-name-year.label'
+        expect(context).toEqual(expect.objectContaining({
+          day: expect.objectContaining({
+            label: 'name.space.fields.field-name-day.label'
+          }),
+          month: expect.objectContaining({
+            label: 'name.space.fields.field-name-month.label'
+          }),
+          year: expect.objectContaining({
+            label: 'name.space.fields.field-name-year.label'
+          })
         }));
       });
 
       it('sets a date boolean to conditionally show input errors', () => {
         middleware(req, res, next);
-        res.locals['input-date']().call(res.locals, 'field-name');
+        res.locals.inputDate('field-name');
 
-        render.getCall(2).should.have.been.calledWith(sinon.match({
-          date: true
-        }));
-        render.getCall(4).should.have.been.calledWith(sinon.match({
-          date: true
-        }));
-        render.getCall(6).should.have.been.calledWith(sinon.match({
+        const context = renderSpy.mock.calls[0][1];
+
+        expect(context).toEqual(expect.objectContaining({
           date: true
         }));
       });
@@ -2079,7 +2022,7 @@ describe('Template Mixins', () => {
           key: 'date-field',
           html: html
         };
-        expect(res.locals.renderField(field)).toBe(html);
+        expect(String(res.locals.renderField(field))).toBe(html);
       });
 
       it('looks up a mixin from res.locals and calls it', () => {


### PR DESCRIPTION
## What? 
[HOFF-2031](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2031) -  Nunjucks Refactoring (Input Date Mixin)
## Why? 
part of nunjucks refactoring work
## How? 
- converted component/templates/date.html to use govuk nunjucks component
- converted input-text-date.html to use govuk nunjucks component
- refactored template mixins so input date works with renderField
- refactored input date unit tests
- Change dreferences from input-date to inputDate
- removed :not(govuk-body) because it overrides styling for p tags with other govuk classes, e.g. error messages
- amended error colour in sandbox/app.scss after v6 update
- added missing safe filter to radio group legend
- fixed spacing in option-group.html and cookies.html
## Testing?
tested locally in sandbox and ARE
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
