### PR TITLE
HOFF-2038 and HOFF-2039: Nunjucks Refactoring(Grouped Input Text and Grouped Input Select mixins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,7 +1027,7 @@ const amountWithUnitSelectComponent = require("hof").components.amountWithUnitSe
 
 module.exports = {
   "amountWithUnitSelect-field": amountWithUnitSelectComponent("amountWithUnitSelect", {
-    mixin: 'input-amount-with-unit-select',
+    mixin: 'inputAmountWithUnitSelect',
     amountLabel: "Amount:", // If not specified, defaults to 'Amount'
     unitLabel: "Unit:", // If not specified, defaults to 'Unit'
     options: [
@@ -1739,7 +1739,7 @@ select
 inputText
 inputFile
 inputDate
-input-amount-with-unit-select
+inputAmountWithUnitSelect
 inputTextCompound
 inputTextCode
 inputNumber

--- a/components/amount-with-unit-select/templates/amount-with-unit-select.html
+++ b/components/amount-with-unit-select/templates/amount-with-unit-select.html
@@ -1,20 +1,35 @@
-<div class="govuk-form-group {{#error}}govuk-form-group--error{{/error}}">
-<fieldset id="{{key}}-group" class="govuk-fieldset{{#className}} {{className}}{{/className}}" role="group">
-  <legend class="govuk-fieldset__legend {{#isPageHeading}}govuk-fieldset__legend--l{{/isPageHeading}}{{#legendClassName}} {{legendClassName}}{{/legendClassName}}">
-    {{#isPageHeading}}<h1 class="govuk-fieldset__heading">{{/isPageHeading}}
-      {{legend}}
-    {{#isPageHeading}}</h1>{{/isPageHeading}}
-  </legend>
-    {{#hint}}
-      <span id="{{key}}-hint" class="govuk-hint">{{hint}}</span>
-    {{/hint}}
-    {{#error}}
-      <p id="{{key}}-error" class="govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span> {{error.message}}
-      </p>
-    {{/error}}
-  <div id="{{key}}" class="govuk-amount-with-unit-select-input">
-    {{#input-amount-with-unit-select}}{{key}}{{/input-amount-with-unit-select}}
-  </div>
-</fieldset>
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{#-------------------------------------------#}
+{#  Set classes                              #}
+{#-------------------------------------------#}
+{% set legendClasses = "" %}
+{% set classes = className or "" %}
+{% set legendClasses = legendClasses + "govuk-fieldset__legend--l " if isPageHeading %}
+
+<div class="govuk-form-group{% if error %} govuk-form-group--error{% endif %}">
+  {% call govukFieldset({
+    attributes: { id: key + "-group" },
+    role: "group",
+    legend: {
+      html: legend | safe,
+      classes: legendClasses + (legendClassName if legendClassName),
+      isPageHeading: isPageHeading
+    },
+    classes: classes
+  }) %}
+  {% if hint %}
+    <div id="{{ key }}-hint" class="govuk-hint">
+      {{ hint | safe }}
+    </div>
+  {% endif %}
+  {% if error %}
+    <p id="{{ key }}-error" class="govuk-error-message">
+      <span class="govuk-visually-hidden">Error:</span> {{ error.message }}
+    </p>
+  {% endif %}
+    <div id="{{ key }}" class="govuk-amount-with-unit-select-input">
+      {{ inputAmountWithUnitSelect(key) }}
+    </div>
+  {% endcall %}
 </div>

--- a/controller/controller.js
+++ b/controller/controller.js
@@ -223,7 +223,7 @@ module.exports = class Controller extends BaseController {
           } else if (field && field.mixin === 'inputDate') {
             // get first field for date input control
             req.form.errors[key].errorLinkId = key + '-day';
-          } else if (field && field.mixin === 'input-amount-with-unit-select') {
+          } else if (field && field.mixin === 'inputAmountWithUnitSelect') {
             // get first field for amount-unit input control
             req.form.errors[key].errorLinkId = key + '-amount';
           } else {

--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -653,48 +653,56 @@ module.exports = function (options) {
           );
         }
       },
-      'input-amount-with-unit-select': {
-        handler: function () {
-          return function (key) {
-            key = (key === '{{key}}' || key === '' || key === undefined) ? nunjucksRender(key, this) : key;
-            const field = Object.assign({}, this.options.fields[key] || options.fields[key]);
+      inputAmountWithUnitSelect: {
+        handler: function (key) {
+          const field = Object.assign({}, this.options.fields[key] || options.fields[key]);
+          key = nunjucksRender(key, this);
 
-            let autocomplete = field.autocomplete || 'off';
-            if (autocomplete === 'off') {
-              autocomplete = { amount: 'off' };
-            } else if (typeof autocomplete === 'string') {
-              autocomplete = { amount: autocomplete + '-amount' };
-            }
+          let autocomplete = field.autocomplete || {};
+          if (autocomplete === 'off') {
+            autocomplete = { amount: 'off' };
+          } else if (typeof autocomplete === 'string') {
+            autocomplete = { amount: autocomplete + '-amount' };
+          }
+          const formGroupClassName = (field.formGroup && field.formGroup.className) ? field.formGroup.className : '';
+          const classNameAmount = (field.controlsClass && field.controlsClass.amount) ? field.controlsClass.amount : 'govuk-input--width-3';
+          const classNameUnit = (field.controlsClass && field.controlsClass.unit) ? field.controlsClass.unit : 'govuk-input--width-5';
+          const context = {
+            options: { fields: this.options.fields || {} },
+            values: res.locals.values || {},
+            errors: res.locals.errors || {}
+          };
 
-            const formGroupClassName = (field.formGroup && field.formGroup.className) ? field.formGroup.className : '';
-            const classNameAmount = (field.controlsClass && field.controlsClass.amount) ? field.controlsClass.amount : 'govuk-input--width-3';
-            const classNameUnit = (field.controlsClass && field.controlsClass.unit) ? field.controlsClass.unit : 'govuk-input--width-5';
+          const parts = [];
 
-            const parts = [];
-
-            // basically does the '_.each(mixins, function (mixin, name)' part manually (which renders the HTML
-            // for both child components and looks for a 'renderWith' and optional 'Options' method to use)
-            const amountPart = nunjucksEnv.renderString(compiled['partials/forms/grouped-inputs-text'], inputText.call(this,
-              key + '-amount', {
+          // basically does the '_.each(mixins, function (mixin, name)' part manually (which renders the HTML
+          // for both child components and looks for a 'renderWith' and optional 'Options' method to use)
+          const amountPart = nunjucksEnv.renderString(
+            compiled['partials/forms/grouped-inputs-text'],
+            inputText.call(context, key + '-amount',
+              {
                 formGroupClassName,
                 autocomplete: autocomplete.amount,
                 className: classNameAmount,
                 amountWithUnitSelect: true
               }
-            ));
+            )
+          );
 
-            const unitPart = nunjucksEnv.renderString(compiled['partials/forms/grouped-inputs-select'], inputText.call(this, key + '-unit',
-              optionGroup.call(this,
-                key + '-unit', {
-                  formGroupClassName,
-                  className: classNameUnit,
-                  amountWithUnitSelect: true
-                },
-                key
+          const unitPart = nunjucksEnv.renderString(
+            compiled['partials/forms/grouped-inputs-select'],
+            inputText.call(context, key + '-unit',
+              optionGroup.call(context, key + '-unit', {
+                formGroupClassName,
+                className: classNameUnit,
+                amountWithUnitSelect: true
+              },
+              key
               )));
 
-            return parts.concat(amountPart, unitPart).join('\n');
-          };
+          parts.push(amountPart, unitPart);
+          const template = parts.join('\n');
+          return new nunjucks.runtime.SafeString(template);
         }
       }
     };
@@ -752,7 +760,11 @@ module.exports = function (options) {
         key = baseCtx;
       }
 
-      const ctx = Object.assign({}, res.locals, baseCtx, key);
+      const ctx = Object.assign({}, res.locals, key, {
+        options: baseCtx.options,
+        values: baseCtx.values,
+        errors: baseCtx.errors
+      });
 
       if (ctx.disableRender) {
         return null;
@@ -784,8 +796,7 @@ module.exports = function (options) {
         const opts = arguments[0];
         const key = arguments[1];
 
-        const ctx = Object.create(this);
-        ctx.options = opts;
+        const ctx = Object.assign({}, this, { options: opts });
 
         return renderFieldImpl.call(ctx, key);
       }

--- a/frontend/template-mixins/partials/forms/grouped-inputs-select.html
+++ b/frontend/template-mixins/partials/forms/grouped-inputs-select.html
@@ -1,13 +1,58 @@
-<div class="{{amountWithUnitSelectItemClassName}}">
-  <div id="{{id}}-group" class="{{#compound}} form-group-compound{{/compound}}{{#formGroupClassName}} {{formGroupClassName}}{{/formGroupClassName}}">
-      <label for="{{id}}" class="{{labelClassName}}">
-        <span class="label-text">{{{label}}}</span>
-      </label>
-      {{#hint}}<div {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{{hint}}}</div>{{/hint}}
-      <select id="{{id}}" class="govuk-select{{#className}} {{className}}{{/className}}{{#error}} govuk-select--error{{/error}}" name="{{id}}" aria-required="{{required}}">
-      {{#options}}
-          <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>
-      {{/options}}
-      </select>
-  </div>
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{#-------------------------------------------#}
+{#  Set form group and label classes         #}
+{#-------------------------------------------#}
+{% set formGroupClasses = "" %}
+
+{% set formGroupClasses = formGroupClasses + formGroupClassName if formGroupClassName %}
+
+
+{#------------------------------------------#}
+{#  Set hint object if hint exists          #}
+{#------------------------------------------#}
+{% set hintObj = null %}
+{% if hint %}
+  {% set hintObj = {
+    html: hint | safe,
+    classes: "govuk-hint",
+    id: hintId
+  } %}
+{% endif %}
+
+{#------------------------------------------#}
+{#  Set error object if error exists        #}
+{#------------------------------------------#}
+{% set errorObj = null %}
+{% if error %}
+  {% set errorObj = {
+    text: error.message,
+    id: error.id
+  } %}
+{% endif %}
+
+{#----------------------------------------------#}
+{#  Set govukSelect args                         #}
+{#----------------------------------------------#}
+{% set args = {
+  id: id,
+  name: id,
+  value: value,
+  formGroup: {
+    classes: formGroupClasses
+  },
+  label: {
+    html: label | safe,
+    classes: labelClassName,
+    for: id
+  },
+  hint: hintObj,
+  classes: className + ("govuk-select--error" if error),
+  items: items,
+  attributes: {
+    "aria-required": required
+  }
+} %}
+<div class="{{ amountWithUnitSelectItemClassName }}">
+  {{ govukSelect(args) }}
 </div>

--- a/frontend/template-mixins/partials/forms/grouped-inputs-text.html
+++ b/frontend/template-mixins/partials/forms/grouped-inputs-text.html
@@ -1,37 +1,78 @@
-<div class="{{amountWithUnitSelectItemClassName}}"> 
-    <div id="{{id}}-group" class="{{#formGroupClassName}} {{formGroupClassName}}{{/formGroupClassName}}">
-      <label for="{{id}}" class="{{labelClassName}}">
-          <span class="label-text">{{{label}}}</span>
-      </label>
-      {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="govuk-hint">{{{hint}}}</span>{{/hint}}
-      {{#renderChild}}{{/renderChild}}
-          {{#attributes}}
-              {{#prefix}}
-                  <div class="govuk-input__prefix" aria-hidden="true">{{prefix}}</div>
-              {{/prefix}}
-          {{/attributes}}
-          <input
-              type="{{type}}"
-              name="{{id}}"
-              id="{{id}}"
-              class="govuk-input{{#className}} {{className}}{{/className}}{{#error}} govuk-input--error{{/error}}"
-              aria-required="{{required}}"
-              {{#value}} value="{{value}}"{{/value}}
-              {{#min}} min="{{min}}"{{/min}}
-              {{#max}} max="{{max}}"{{/max}}
-              {{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}
-              {{#pattern}} pattern="{{pattern}}"{{/pattern}}
-              {{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}
-              {{#error}} aria-invalid="true"{{/error}}
-              {{#autocomplete}} autocomplete="{{autocomplete}}"{{/autocomplete}}
-              {{#attributes}}
-                  {{attribute}}="{{value}}"
-              {{/attributes}}
-          >
-          {{#attributes}}
-              {{#suffix}}
-                  <div class="govuk-input__prefix" aria-hidden="true">{{suffix}}</div>
-              {{/suffix}}
-          {{/attributes}}
-    </div>
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{#-------------------------------------------#}
+{#  Set form group classes                   #}
+{#-------------------------------------------#}
+{% set formGroupClasses = "" %}
+
+{% set formGroupClasses = formGroupClasses + formGroupClassName if formGroupClassName %}
+
+{#------------------------------------------#}
+{#  Set hint object if hint exists          #}
+{#------------------------------------------#}
+{% set hintObj = null %}
+{% if hint %}
+  {% set hintObj = {
+    html: hint | safe,
+    classes: "govuk-hint",
+    id: hintId
+  } %}
+{% endif %}
+
+{#------------------------------------------#}
+{#  Set error object if error exists        #}
+{#------------------------------------------#}
+{% set errorObj = null %}
+{% if error %}
+  {% set errorObj = {
+    text: error.message,
+    id: error.id
+  } %}
+{% endif %}
+
+{#----------------------------------------------#}
+{#  Set beforeInput HTML from renderChild()     #}
+{#----------------------------------------------#}
+{% if renderChild is defined %}
+  {% set beforeInputObj = { html: renderChild({}) | safe } %}
+{% else %}
+  {% set beforeInputObj = undefined %}
+{% endif %}
+
+{#----------------------------------------------#}
+{#  Set prefix and suffix text                  #}
+{#----------------------------------------------#}
+{% if prefix or suffix is defined %}
+  {% set prefixObj = { text: prefix } %}
+  {% set suffixObj = { text: suffix } %}
+{% endif %}
+
+{#----------------------------------------------#}
+{#  Set govukInput args                         #}
+{#----------------------------------------------#}
+{% set args = {
+  formGroup: {
+    classes: formGroupClasses,
+    beforeInput: beforeInputObj
+  },
+  label: {
+    html: label | safe,
+    classes: labelClassName,
+    for: id
+  },
+  hint: hintObj,
+  prefix: prefixObj,
+  suffix: suffixObj,
+  classes: className + (" govuk-input--error" if error),
+  id: id,
+  name: id,
+  type: type,
+  autocomplete: autocomplete,
+  value: value,
+  pattern: pattern,
+  attributes: attributes,
+  disabled: disabled
+} %}
+<div class="{{ amountWithUnitSelectItemClassName }}"> 
+    {{ govukInput(args) }}
 </div>

--- a/sandbox/apps/sandbox/fields.js
+++ b/sandbox/apps/sandbox/fields.js
@@ -127,7 +127,7 @@ module.exports = {
     }].concat(staticAppealStages.getstaticAppealStages())
   },
   'amountWithUnitSelect' : amountWithUnitSelectComponent('amountWithUnitSelect', {
-    mixin: 'input-amount-with-unit-select',
+    mixin: 'inputAmountWithUnitSelect',
     amountLabel: "Amount-",
     unitLabel: "Unit-",
     options: [

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -632,52 +632,40 @@ describe('Template Mixins', () => {
       });
     });
 
-    describe('input-amount-with-unit-select', () => {
+    describe('inputAmountWithUnitSelect', () => {
+      beforeEach(() => {
+        res.locals.options = {
+          fields: {
+            'field-name': {}
+          }
+        };
+      });
+
       it('adds a function to res.locals', () => {
         middleware(req, res, next);
-        res.locals['input-amount-with-unit-select'].should.be.a('function');
+        expect(typeof res.locals.inputAmountWithUnitSelect).toBe('function');
       });
 
-      it('returns a function', () => {
+      it('returns an object', () => {
         middleware(req, res, next);
-        res.locals['input-amount-with-unit-select']().should.be.a('function');
+        expect(typeof res.locals.inputAmountWithUnitSelect('field-name')).toBe('object');
       });
 
-      it('renders 6 times if the field is not marked as inexact', () => {
+      it('renders 7 times if the field is not marked as inexact', () => {
         middleware(req, res, next);
-        res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
-        render.callCount.should.be.equal(6);
+        res.locals.inputAmountWithUnitSelect('field-name');
+        expect(renderSpy).toHaveBeenCalledTimes(7);
       });
 
       it('looks up field label', () => {
         middleware(req, res, next);
-        res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
+        res.locals.inputAmountWithUnitSelect('field-name');
 
-        render.called;
-
-        const amountCall = render.getCall(1);
-
-        amountCall.should.have.been.calledWith(sinon.match({
-          label: 'fields.field-name-amount.label'
-        }));
-      });
-
-      it('govuk-form-group class is set in the amountWithUnitSelect fields by default', () => {
-        middleware(req, res, next);
-        res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
-
-        render.called;
-
-        const amountCall = render.getCall(1);
-        const unitCall = render.getCall(5);
-
-        amountCall.should.have.been.calledWith(sinon.match({
-          formGroupClassName: 'govuk-form-group'
-        }));
-
-        unitCall.should.have.been.calledWith(sinon.match({
-          formGroupClassName: 'govuk-form-group'
-        }));
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            label: 'fields.field-name-amount.label'
+          }));
       });
 
       describe('autocomplete', () => {
@@ -688,15 +676,13 @@ describe('Template Mixins', () => {
             }
           };
           middleware(req, res, next);
-          res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
+          res.locals.inputAmountWithUnitSelect('field-name');
 
-          render.should.have.been.called;
-
-          const amountCall = render.getCall(1);
-
-          amountCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'amount-with-unit-select-amount'
-          }));
+          expect(renderSpy).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              autocomplete: 'amount-with-unit-select-amount'
+            }));
         });
 
         it('should be set as exact values if an object is given', () => {
@@ -708,15 +694,13 @@ describe('Template Mixins', () => {
             }
           };
           middleware(req, res, next);
-          res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
+          res.locals.inputAmountWithUnitSelect('field-name');
 
-          render.called;
-
-          const amountCall = render.getCall(1);
-
-          amountCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'amount-with-unit-select-amount'
-          }));
+          expect(renderSpy).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              autocomplete: 'amount-with-unit-select-amount'
+            }));
         });
 
         it('should set autocomplete to off if off is specified', () => {
@@ -726,52 +710,48 @@ describe('Template Mixins', () => {
             }
           };
           middleware(req, res, next);
-          res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
+          res.locals.inputAmountWithUnitSelect('field-name');
 
-          render.called;
-
-          const amountCall = render.getCall(1);
-
-          amountCall.should.have.been.calledWith(sinon.match({
-            autocomplete: 'off'
-          }));
+          expect(renderSpy).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              autocomplete: 'off'
+            }));
         });
 
         it('should default to no attribute across all amountWithUnitSelect fields', () => {
           middleware(req, res, next);
-          res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
+          res.locals.inputAmountWithUnitSelect('field-name');
 
-          render.called;
-
-          const amountCall = render.getCall(0);
-
-          amountCall.should.have.been.calledWith(sinon.match({
-            autocomplete: undefined
-          }));
+          expect(renderSpy).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              autocomplete: 'off'
+            }));
         });
       });
 
       it('prefixes translation lookup with namespace if provided', () => {
         middleware = mixins({ sharedTranslationsKey: 'name.space' });
         middleware(req, res, next);
-        res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
+        res.locals.inputAmountWithUnitSelect('field-name');
 
-        render.called;
-
-        const amountCall = render.getCall(1);
-
-        amountCall.should.have.been.calledWith(sinon.match({
-          label: 'name.space.fields.field-name-amount.label'
-        }));
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            label: 'name.space.fields.field-name-amount.label'
+          }));
       });
 
       it('sets a amountWithUnitSelect boolean to conditionally show input errors', () => {
         middleware(req, res, next);
-        res.locals['input-amount-with-unit-select']().call(res.locals, 'field-name');
+        res.locals.inputAmountWithUnitSelect('field-name');
 
-        render.getCall(1).should.have.been.calledWith(sinon.match({
-          amountWithUnitSelect: true
-        }));
+        expect(renderSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            amountWithUnitSelect: true
+          }));
       });
     });
 


### PR DESCRIPTION
## What? 
[HOFF-2038](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2038) - Nunjucks Refactoring (Grouped Inputs Text Mixin) and [HOFF-2039](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2039) - Nunjucks Refactoring (Grouped Input Select Mixin)
## Why? 
part of nunjucks refactoring work
## How? 
HOFF-2038: Nunjucks Refactoring(Grouped Input Text mixin)
- converted grouped-input-text.html to govuk nunjucks component


HOFF-2039: Nunjucks Refactoring( Grouped Input Select mixin)
- converted grouped-input-select.html to govuk nunjucks component
- converted components/amount-with-unit-select/templates/amount-with-unit-select.html to nunjucks templating
- refactored input-amount-with-unit-select function in template-mixins to work with nunjucks
- renamed input-amount-with-unit-select to inputAmountWithUnitSelect
- amended relevant unit tests

- refactored template-mixins to fix date and grouped inputs overriding fields that follow them
## Testing?
tested locally in hof/sandbox
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests - Note all mixin.test.js tests are now passing. functional tests are still failing due to address lookup component not yet been converted, which will be addressed in a separate ticket.
- [x] I will squash the commits before merging
