### PR TITLE
HOFF-2024: Nunjucks Refactoring - Fix bug where toggle in raw html for option-group and checkbox-group views not working

### DIFF
--- a/frontend/template-mixins/partials/forms/checkbox-group.html
+++ b/frontend/template-mixins/partials/forms/checkbox-group.html
@@ -132,37 +132,41 @@
       {% endif %}
 
       <div class="govuk-checkboxes {{ classes }}" data-module="govuk-checkboxes">
-        {% for item in items %}
+        {% for option in options %}
+          {% if option.divider !== "after" and option.behaviour === "exclusive" %}
+          <div class="govuk-checkboxes__divider">or</div>
+          {% endif %}
           <div class="govuk-checkboxes__item">
             <input class="govuk-checkboxes__input"
-                  id="{{ item.id }}"
-                  name="{{ item.name }}"
-                  type="checkbox"
-                  value="{{ item.value }}"
-                  {% if item.checked %}checked{% endif %}
-                  {% if item.conditional %}
-                    aria-controls="conditional-{{ item.id }}"
+                  id="{{ key }}-{{ option.value }}"
+                  name="{{ key}}"
+                  type="{{ option.type }}"
+                  value="{{ option.value }}"
+                  {% if option.selected %}checked{% endif %}
+                  {% if option.toggle %}
+                    aria-controls="conditional-{{ key }}-{{ option.value }}"
                   {% endif %}
-                  {% for attr, val in item.attributes|default({}) %}
+                  {% for attr, val in option.attributes|default({}) %}
                     {{ attr }}="{{ val }}"
                   {% endfor %}>
 
-            <label class="govuk-label govuk-checkboxes__label" for="{{ item.id }}">
-              {{ item.html | safe }}
+            <label class="govuk-label govuk-checkboxes__label" for="{{ key }}-{{ option.value }}">
+              {{ option.label | safe }}
             </label>
 
-            {% if item.hint %}
-              <div class="govuk-hint govuk-checkboxes__hint">
-                {{ item.hint.text | safe }}
-              </div>
+            {% if option.optionHint %}
+              <div id="{{ key }}-{{ option.value }}-item-hint" class="govuk-hint govuk-checkboxes__hint">{{ option.optionHint }}</div>
             {% endif %}
           </div>
-          {% if item.conditional %}
-            <div id="conditional-{{ item.id }}"
-            class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}"
-            aria-hidden="{% if not item.checked %}true{% else %}false{% endif %}">
-              {{ item.conditional.html | safe }}
+          {% if option.toggle %}
+            <div id="conditional-{{ key }}-{{ option.value }}"
+            class="govuk-checkboxes__conditional{% if not option.selected %} govuk-checkboxes__conditional--hidden{% endif %}"
+            aria-hidden="{% if not option.selected %}true{% else %}false{% endif %}">
+              {{ renderChild(option) | safe }}
             </div>
+          {% endif %}
+          {% if option.divider === "after" and option.behaviour === "exclusive" %}
+          <div class="govuk-checkboxes__divider">or</div>
           {% endif %}
         {% endfor %}
       </div>

--- a/frontend/template-mixins/partials/forms/option-group.html
+++ b/frontend/template-mixins/partials/forms/option-group.html
@@ -131,37 +131,41 @@
       {% endif %}
 
       <div class="govuk-radios {{ classes }}" data-module="govuk-radios">
-        {% for item in items %}
+        {% for option in options %}
+        {% if option.divider and option.divider !== "after" %}
+        <div class="govuk-radios__divider">or</div>
+        {% endif %}
           <div class="govuk-radios__item">
             <input class="govuk-radios__input"
-                  id="{{ item.id }}"
-                  name="{{ item.name }}"
-                  type="checkbox"
-                  value="{{ item.value }}"
-                  {% if item.checked %}checked{% endif %}
-                  {% if item.conditional %}
-                    aria-controls="conditional-{{ item.id }}"
+                  id="{{ key }}-{{ option.value }}"
+                  name="{{ key }}"
+                  type="{{ option.type }}"
+                  value="{{ option.value }}"
+                  {% if option.selected %}checked{% endif %}
+                  {% if option.toggle %}
+                    aria-controls="conditional-{{ key }}-{{ option.value }}"
                   {% endif %}
-                  {% for attr, val in item.attributes|default({}) %}
+                  {% for attr, val in option.attributes|default({}) %}
                     {{ attr }}="{{ val }}"
                   {% endfor %}>
 
-            <label class="govuk-label govuk-radios__label" for="{{ item.id }}">
-              {{ item.html | safe }}
+            <label class="govuk-label govuk-radios__label" for="{{ key }}-{{ option.value }}">
+              {{ option.label | safe }}
             </label>
 
-            {% if item.hint %}
-              <div class="govuk-hint govuk-radios__hint">
-                {{ item.hint.text | safe }}
-              </div>
+            {% if option.optionHint %}
+              <div id="{{ key }}-{{ option.value }}-item-hint" class="govuk-hint govuk-radios__hint">{{ option.optionHint }}</div>
             {% endif %}
           </div>
-          {% if item.conditional %}
-            <div id="conditional-{{ item.id }}"
-            class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}"
-            aria-hidden="{% if not item.checked %}true{% else %}false{% endif %}">
-              {{ item.conditional.html | safe }}
+          {% if option.toggle %}
+            <div id="conditional-{{ key }}-{{ option.value }}"
+            class="govuk-radios__conditional{% if not option.selected %} govuk-radios__conditional--hidden{% endif %}"
+            aria-hidden="{% if not option.selected %}true{% else %}false{% endif %}">
+              {{ renderChild(option) | safe }}
             </div>
+          {% endif %}
+          {% if option.divider and option.divider === "after" %}
+          <div class="govuk-radios__divider">or</div>
           {% endif %}
         {% endfor %}
       </div>


### PR DESCRIPTION
## What? 
Bugfixes for bugs found when testing on other services 
## Why? 
part of nunjucks refactoring and frontend update work - [HOFF-2024](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2024)
## How? 
- added correct option properties  to raw html  version for option-group and checkbox-group views  to fix bug where toggle in raw html  version for option-group and checkbox-group views was not working.
## Testing?
tested locally on sandbox and BRP
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging

