### PR TITLE
HOFF-2024: Nunjucks Refactoring (bug fix) - Fix framework views like layout not being overridden by custom service level equivalent

### DIFF
--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -94,8 +94,14 @@ module.exports = function (options) {
 
     // use nunjucks environment for resolving includes/partials from the
     // project's views roots for this request.
-    const nunjucksEnv = (req && req.app && req.app.locals && req.app.locals.nunjucksEnv);
+    // function getNunjucksEnv(req) {
+    //   const routeName = req?.res?.locals?.routeName;
+    //   return getEnvForRoute(routeName);
+    // }
+    // const nunjucksEnv = getNunjucksEnv(req);
 
+    // const nunjucksEnv = (req && req.app && req.app.locals && req.app.locals.nunjucksEnv);
+    const nunjucksEnv = req?.res?.locals?.nunjucksEnv;
 
     // helper: resolve a template file path by trying express View, configured viewsDirectory and app roots
     function resolveTemplateFile(name) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -52,67 +52,103 @@ module.exports = async (app, config) => {
   app.set('views', viewPaths);
   app.use(expressPartialTemplates(app));
 
-  const nunjucksRoots = [];
-
-  // add the app views to the Nunjucks roots, so that the resolved path can be found by the Nunjucks loader
-  const findAppViewPaths = rootDir => {
-    const results = [];
-    // avoid checking 'node modules'
-    const IGNORE_DIRS = new Set(['node_modules']);
-    const addDir = dir => {
-      const entries = fs.readdirSync(dir, { withFileTypes: true });
-      for (const entry of entries) {
-        if (IGNORE_DIRS.has(entry.name)) continue;
-        const fullPath = path.join(dir, entry.name);
-
-        if (entry.isDirectory()) {
-          if (entry.name === 'views') {
-            results.push(fullPath);
-          } else {
-            addDir(fullPath);
-          }
-        }
-      }
-    };
-
-    addDir(rootDir);
-    return results;
-  };
-
-  const appViewPaths = findAppViewPaths(config.root);
-
-  nunjucksRoots.push(...viewPaths, ...appViewPaths);
-
-  try {
-    const govukPkg = require.resolve('govuk-frontend/package.json', { paths: [config.root || process.cwd()] });
-    const govukRoot = path.dirname(govukPkg);
-    nunjucksRoots.push(govukRoot);
-    nunjucksRoots.push(path.join(govukRoot, 'dist'));
-  } catch (e) {
-    /* eslint-disable-next-line no-console */
-    console.debug('govuk-frontend not resolved via require.resolve; ensure package is installed if needed');
-  }
-
-  // dedupe and keep only existing directories
-  const uniqueRoots = Array.from(new Set(nunjucksRoots)).filter(p => {
-    try { return fs.existsSync(p) && fs.lstatSync(p).isDirectory(); } catch (e) { return false; }
-  });
-
   const isLocalDev = process.env.NODE_ENV === 'local';
 
-  // configure nunjucks and keep the env for other modules if needed
-  const nunjucksEnv = nunjucks.configure(uniqueRoots, {
-    autoescape: true,
-    express: app,
-    watch: isLocalDev,
-    noCache: isLocalDev
+  const govukPkg = require.resolve('govuk-frontend/package.json', {
+    paths: [config.root || process.cwd()]
+  });
+  const govukRoot = path.dirname(govukPkg);
+
+  const envCache = new Map();
+
+  function getEnvForRoute(routeName) {
+    const key = routeName || 'common';
+
+    if (envCache.has(key)) {
+      return envCache.get(key);
+    }
+
+    const paths = [];
+
+    if (routeName) {
+      paths.push(path.join(process.cwd(), 'apps', routeName, 'views'));
+    }
+
+    paths.push(path.join(process.cwd(), 'apps/common/views'));
+    paths.push(...viewPaths);
+    paths.push(govukRoot);
+    paths.push(path.join(govukRoot, 'dist'));
+
+    const loader = new nunjucks.FileSystemLoader(paths, {
+      noCache: isLocalDev
+    });
+
+    const env = new nunjucks.Environment(loader, {
+      autoescape: true,
+      watch: isLocalDev,
+      noCache: isLocalDev
+    });
+
+    envCache.set(key, env);
+    return env;
+  }
+
+  app.use((req, res, next) => {
+    res.locals.req = req;
+    res.locals.nunjucksEnv = getEnvForRoute(res.locals.routeName);
+    next();
   });
 
-  // expose the same env so other modules/middlewares can reuse it
-  app.locals.nunjucksEnv = nunjucksEnv;
+  const matchBaseUrlRoute = (url, routes) => {
+    return routes.find(r =>
+      r.baseUrl &&
+      (
+        url === r.baseUrl ||
+        url.startsWith(r.baseUrl + '/')
+      )
+    );
+  };
+
+  const matchRootStepRoute = (url, routes) => {
+    const segments = url.split('/').filter(Boolean);
+
+    // only root-level URLs
+    if (segments.length !== 1) return null;
+
+    const first = `/${segments[0]}`;
+
+    return routes.find(r =>
+      !r.baseUrl &&
+      r.steps &&
+      r.steps[first]
+    );
+  };
+
+  const matchRoute = (req, routes) => {
+    const url = req.originalUrl;
+
+    const baseUrlMatch = matchBaseUrlRoute(url, routes);
+    if (baseUrlMatch) return baseUrlMatch;
+
+    const rootStepMatch = matchRootStepRoute(url, routes);
+    if (rootStepMatch) return rootStepMatch;
+
+    return null;
+  };
 
   app.set('view engine', viewEngine);
-  app.engine(viewEngine, nunjucksEnv.render.bind(nunjucksEnv));
+  app.engine(viewEngine, (filePath, context, callback) => {
+    const req = context.req;
+
+    const matchedRoute = matchRoute(req, config.routes);
+    const routeName = matchedRoute?.name;
+
+    const env = getEnvForRoute(routeName);
+    app.locals.nunjucksEnv = env;
+
+    env.render(filePath, context, callback);
+  });
+
 
   app.use(bodyParser.urlencoded({
     extended: true

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -34,9 +34,11 @@ describe('Template Mixins', () => {
       locals: {
         options: {
           fields: {}
-        }
+        },
+        nunjucksEnv
       }
     };
+    req.res = res;
 
     next = jest.fn();
 


### PR DESCRIPTION
## What? 
Bugfix for bugs found when testing on other services - framework template partials like layout.html were not being overriden when a custom version had been created at a service level.
## Why? 
part of nunjucks refactoring and frontend update work - [HOFF-2024](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2024)part of nunjucks refactoring and frontend update work - [HOFF-2024](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2024)
## How? 
- refactored lib/settings.js so that custom service level views can override corresponding framework views e.g. layout.html when configuring nunjucks
- updated how template-mixins.js and mixins test calls nunjucks environment after changes to lib/settings
## Testing?
tested locally in sandbox and in PAF
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
