### PR TITLE
HOFF-2045 Nunjucks Refactoring-Items-Table

### DIFF
--- a/frontend/template-partials/views/partials/items-table.html
+++ b/frontend/template-partials/views/partials/items-table.html
@@ -1,32 +1,36 @@
-{{#hasItems}}
-<div class="loop-summary-table">
-    {{#items}}
-    <table class="govuk-table">
-        <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header data-col" colspan="2">{{itemTitle}}</th>
-            <th scope="col" class="govuk-table__header action-col">
-                <a href="{{baseUrl}}/{{route}}/edit/{{index}}">{{#t}}buttons.edit{{/t}}<span class="visuallyhidden"> {{itemTitle}}</span></a>
-            </th>
-            <th scope="col" class="govuk-table__header action-col">
-                <a href="{{baseUrl}}/{{route}}/delete/{{index}}">{{#t}}buttons.delete{{/t}}<span
-                        class="visuallyhidden"> {{itemTitle}}</span></a>
-            </th>
-        </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-        {{#fields}}
-        {{#showInSummary}}
-        <tr class="govuk-table__row">
-            <td class="govuk-table__cell" class="govuk-table__header data-col">{{#t}}fields.{{field}}{{/t}}</td>
-            <td></td>
-            <td class="govuk-table__cell" class="govuk-table__header data-col">{{#parsed}}{{parsed}}{{/parsed}}{{^parsed}}{{value}}{{/parsed}}</td>
-            <td></td>
-        </tr>
-        {{/showInSummary}}
-        {{/fields}}
-        </tbody>
-    </table>
-    {{/items}}
-</div>
-{{/hasItems}}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% if hasItems %}
+  {% for item in items %}
+    {% set summaryRows = [] %}
+    {% set actions = null %}
+    {% set actions = { 
+      items: [
+      {
+        href: baseUrl+ "/" + route + "/edit/" + item.index,
+        text: t('buttons.edit'),
+        visuallyHiddenText: item.itemTitle
+      },
+      {
+        href: baseUrl+ "/" + route + "/delete/" + item.index,
+        text: t('buttons.delete'),
+        visuallyHiddenText: item.itemTitle
+      }
+      ]} %}
+            
+    {% set summaryRow = {
+      key: { text: item.itemTitle },
+      actions: actions} %}
+    {% if item.fields %}
+      {% for row in item.fields %}
+        {% if row.showInSummary %}
+          {% set summaryRow = {
+              key: { text: t('fields.' + row.field),  classes: "summary-list-key-not-bold"},
+            value: { html: row.parsed if row.parsed else row.value }
+          } %}
+        {% endif %}
+        {% set summaryRows = summaryRows.concat([summaryRow]) %}
+      {% endfor %}
+    {% endif %}
+    {{ govukSummaryList({rows: summaryRows}) }}
+  {% endfor %}
+{% endif %}

--- a/sandbox/apps/sandbox/behaviours/aggregator.js
+++ b/sandbox/apps/sandbox/behaviours/aggregator.js
@@ -1,0 +1,215 @@
+const path = require('path');
+
+module.exports = superclass => class extends superclass {
+  constructor(options) {
+    if (!options.aggregateTo) {
+      throw new Error('options.aggregateTo is required for loops');
+    }
+    if (!options.aggregateFrom) {
+      throw new Error('options.aggregateField is required for loops');
+    }
+    super(options);
+  }
+
+  deleteItem(req, res) {
+    const id = req.params.id;
+
+    if (id) {
+      const items = this.getAggregateArray(req).filter((element, index) => index !== parseInt(id, 10));
+      this.setAggregateArray(req, items);
+    }
+    res.redirect(`${req.baseUrl}${req.form.options.route}`);
+  }
+
+  updateItem(req, res) {
+    const id = req.sessionModel.get(`${req.form.options.aggregateTo}-itemToReplaceId`);
+    const items = this.getAggregateArray(req);
+
+    let itemTitle = '';
+
+    req.form.options.aggregateFrom.forEach(aggregateFromElement => {
+      const aggregateFromField = aggregateFromElement.field || aggregateFromElement;
+
+      if (req.form.options.titleField === aggregateFromField) {
+        itemTitle = req.sessionModel.get(aggregateFromField);
+      }
+
+      const value = req.sessionModel.get(aggregateFromField);
+
+      const fieldToUpdate = items[id].fields.find(field => field.field === aggregateFromField);
+
+      fieldToUpdate.value = req.sessionModel.get(aggregateFromField);
+      fieldToUpdate.parsed = this.parseField(aggregateFromElement, value, req);
+
+      req.sessionModel.unset(aggregateFromField);
+    });
+
+    items[id].itemTitle = itemTitle;
+
+    this.setAggregateArray(req, items);
+    req.sessionModel.unset(`${req.form.options.aggregateTo}-itemToReplaceId`);
+
+
+    if (req.sessionModel.get('returnToSummary') && !this.continueOnEdit) {
+      req.sessionModel.unset('returnToSummary');
+      res.redirect(path.join(req.baseUrl, this.confirmStep));
+    } else {
+      res.redirect(`${req.baseUrl}${req.form.options.route}`);
+    }
+  }
+
+  showEditItemPage(req, res) {
+    const items = this.getAggregateArray(req);
+    const id = req.params.id;
+
+    if (req.query.returnToSummary) {
+      req.sessionModel.set('returnToSummary', true);
+    }
+
+    if (id) {
+      req.sessionModel.set(`${req.form.options.aggregateTo}-itemToReplaceId`, id);
+
+      req.form.options.aggregateFrom.forEach(aggregateFromElement => {
+        const aggregateFromField = aggregateFromElement.field || aggregateFromElement;
+
+        req.sessionModel.set(aggregateFromField,
+          items[id].fields.find(field => field.field === aggregateFromField).value);
+      });
+      const field = req.params.field || req.params.edit;
+      const editPath = field ? `/edit#${field}` : '/edit';
+      res.redirect(`${req.baseUrl}/${req.form.options.addStep}${editPath}`);
+    } else {
+      res.redirect(`${req.baseUrl}${req.form.options.route}`);
+    }
+  }
+
+  addItem(req, res) {
+    const items = this.getAggregateArray(req);
+    const fields = [];
+
+    let itemTitle = '';
+
+    req.form.options.aggregateFrom.forEach(aggregateFromElement => {
+      const aggregateFromField = aggregateFromElement.field || aggregateFromElement;
+      const isTitleField = req.form.options.titleField === aggregateFromField;
+      const value = req.sessionModel.get(aggregateFromField);
+
+      if (isTitleField) {
+        itemTitle = value;
+      }
+
+      fields.push({
+        field: aggregateFromField,
+        parsed: this.parseField(aggregateFromField, value, req),
+        value,
+        showInSummary: !isTitleField,
+        changeField: aggregateFromElement.changeField
+      });
+
+      this.setAggregateArray(req, items);
+      req.sessionModel.unset(aggregateFromField);
+    });
+
+    const newItem = { itemTitle, fields };
+
+    items.push(newItem);
+
+    this.setAggregateArray(req, items);
+    res.redirect(`${req.baseUrl}${req.form.options.route}`);
+  }
+
+  getAggregateArray(req) {
+    const aggregateToField = req.sessionModel.get(req.form.options.aggregateTo) || { aggregatedValues: [] };
+    return aggregateToField.aggregatedValues;
+  }
+
+  setAggregateArray(req, value) {
+    req.sessionModel.set(req.form.options.aggregateTo, { aggregatedValues: value });
+  }
+
+  newFieldsProvided(req) {
+    let fieldsProvided = false;
+
+    req.form.options.aggregateFrom.forEach(aggregateFromField => {
+      if (req.sessionModel.get(aggregateFromField)) {
+        fieldsProvided = true;
+      }
+    });
+
+    return fieldsProvided;
+  }
+
+  redirectToAddStep(req, res) {
+    res.redirect(`${req.baseUrl}/${req.form.options.addStep}`);
+  }
+
+  editItem(req, res) {
+    if (req.sessionModel.get(`${req.form.options.aggregateTo}-itemToReplaceId`)) {
+      this.updateItem(req, res);
+    } else {
+      this.showEditItemPage(req, res);
+    }
+  }
+
+  getAction(req) {
+    const noItemsPresent = () => this.getAggregateArray(req).length === 0;
+
+    let action;
+
+    if (this.newFieldsProvided(req)) {
+      action = 'addItem';
+    } else if (noItemsPresent()) {
+      action = 'redirectToAddStep';
+    }
+
+    return action || 'showItems';
+  }
+
+  getValues(req, res, next) {
+    const action = req.params.action || this.getAction(req, res, next);
+    this.handleAction(req, res, next, action);
+  }
+
+  handleAction(req, res, next, action) {
+    switch (action) {
+      case 'delete':
+        this.deleteItem(req, res);
+        break;
+      case 'edit':
+        this.editItem(req, res);
+        break;
+      case 'addItem':
+        this.addItem(req, res);
+        break;
+      case 'redirectToAddStep':
+        this.redirectToAddStep(req, res);
+        break;
+      case 'showItems':
+      default:
+        return Object.assign({}, super.getValues(req, res, next), { redirected: false });
+    }
+    return { redirected: true };
+  }
+
+  parseField(field, value, req) {
+    const fieldName = field.field || field;
+    const parser = req.form.options.fieldsConfig[fieldName].parse;
+    return parser ? parser(value, fieldName, req) : value;
+  }
+
+  locals(req, res) {
+    const items = this.getAggregateArray(req);
+
+    items.forEach((element, index) => {
+      element.index = index;
+    });
+
+    return Object.assign({}, super.locals(req, res), {
+      items,
+      hasItems: items.length > 0,
+      addStep: req.form.options.addStep,
+      field: req.form.options.aggregateTo,
+      addAnotherLinkText: req.form.options.addAnotherLinkText
+    });
+  }
+};

--- a/sandbox/apps/sandbox/fields.js
+++ b/sandbox/apps/sandbox/fields.js
@@ -87,6 +87,18 @@ module.exports = {
     },
     validate: ['required']
   },
+  hasOtherName: {
+    mixin: 'radioGroup',
+    isPageHeading: 'true',
+    validate: ['required'],
+    options: ['yes', 'no']
+  },
+  otherFirstName: {
+    validate: ['required']
+  },
+  otherSurname: {
+    validate: ['required']
+  },
   complaintDetails: {
     mixin: 'textarea',
     // we want to ignore default formatters as we want

--- a/sandbox/apps/sandbox/index.js
+++ b/sandbox/apps/sandbox/index.js
@@ -4,9 +4,11 @@
 const CountrySelect = require('./behaviours/country-select')
 const SummaryPageBehaviour = require('../../../').components.summary;
 const InternationalPhoneNumber = require('./behaviours/international-number');
+const Aggregate = require('./behaviours/aggregator');
 
 module.exports = {
   name: 'sandbox',
+  params: '/:action?/:id?/:field?',
   steps: {
     '/landing-page': {
       fields: [
@@ -67,6 +69,34 @@ module.exports = {
     '/country-select': {
       behaviours: CountrySelect,
       fields: ['countrySelect'],
+      next: '/has-other-name'
+    },
+    '/has-other-name': {
+      fields: ['hasOtherName'],
+      forks: [{
+        target: '/name-details',
+        condition: {
+          field: 'hasOtherName',
+          value: 'yes'
+        }
+       }],
+       next: '/text-input-area'
+    },
+    '/other-name': {
+      fields: ['otherFirstName', 'otherSurname'],
+      next: '/name-details',
+      continueOnEdit: true
+    },
+    '/name-details': {
+      template: 'summary-name-list',
+      behaviours: Aggregate,
+      aggregateTo: 'otherNames',
+      aggregateFrom: [
+        'otherFirstName',
+        'otherSurname',
+      ],
+      titleField: 'otherFirstName',
+      addStep: 'other-name',
       next: '/text-input-area'
     },
     '/text-input-area': {

--- a/sandbox/apps/sandbox/sections/summary-data-sections.js
+++ b/sandbox/apps/sandbox/sections/summary-data-sections.js
@@ -7,6 +7,11 @@ module.exports = {
   applicantsDetails: [
     'name',
     {
+      step: '/name-details',
+      field: 'otherNames',
+      dependsOn: 'hasOtherName'
+    },
+    {
       field: 'dateOfBirth',
       parse: d => d && moment(d).format(PRETTY_DATE_FORMAT)
     }

--- a/sandbox/apps/sandbox/translations/src/en/buttons.json
+++ b/sandbox/apps/sandbox/translations/src/en/buttons.json
@@ -1,0 +1,4 @@
+{
+  "edit": "Edit",
+  "delete": "Delete"
+}

--- a/sandbox/apps/sandbox/translations/src/en/fields.json
+++ b/sandbox/apps/sandbox/translations/src/en/fields.json
@@ -91,6 +91,23 @@
     "label": "Which country are you based in?",
     "hint": "Start to type the country name and options will appear"
   },
+  "hasOtherName": {
+    "legend": "Have you been known by any other names?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "otherFirstName": {
+    "label": "Other first name"
+  },
+  "otherSurname": {
+    "label": "Other surname"
+  },
   "appealStages": {
     "label": "Appeal stage",
     "hint": "Choose an appeal stage from the drop down menu",

--- a/sandbox/apps/sandbox/translations/src/en/pages.json
+++ b/sandbox/apps/sandbox/translations/src/en/pages.json
@@ -19,6 +19,12 @@
   "phone-number": {
     "header": "Enter your phone number"
   },
+  "other-name": {
+    "header": "Other names"
+  },
+  "name-details":{
+    "header": "Other names summary"
+  },
   "confirm": {
     "header": "Check your answers before submitting your application.",
     "sections": {

--- a/sandbox/apps/sandbox/translations/src/en/validation.json
+++ b/sandbox/apps/sandbox/translations/src/en/validation.json
@@ -40,6 +40,15 @@
     "required": "Enter an international phone number",
     "internationalPhoneNumber": "Enter a valid international phone number"
   },
+  "hasOtherName": {
+    "required": "Select an option below and press continue"
+  },
+  "otherFirstName":{
+    "default": "Enter your other first name"
+  },
+  "otherSurname":{
+    "default": "Enter your other surname"
+  },
   "complaintDetails": {
     "default": "Enter details about why you are making a complaint",
     "maxlength": "Keep to the {{maxlength}} character limit"

--- a/sandbox/apps/sandbox/views/summary-name-list.html
+++ b/sandbox/apps/sandbox/views/summary-name-list.html
@@ -1,0 +1,6 @@
+{% extends "partials/page.html" %}
+
+{% block pageContent %}
+  {% include "partials/items-table.html" %}
+  {{ inputSubmit("continue") }}
+{% endblock %}

--- a/sandbox/assets/scss/app.scss
+++ b/sandbox/assets/scss/app.scss
@@ -23,6 +23,7 @@
 .autocomplete__input {
   background-color: transparent;
   position: relative;
+  @extend .govuk-input;
 }
 
 .autocomplete__hint {
@@ -95,7 +96,7 @@
 
 .autocomplete__menu--inline {
   position: relative;
-  @extend .govuk-list
+  @extend .govuk-list;
 }
 
 .autocomplete__option {
@@ -155,4 +156,7 @@
     font-size: 19px;
     line-height: 1.31579;
   }
+}
+.summary-list-key-not-bold{
+  font-weight: 400;
 }

--- a/sandbox/test/_unit/example_app/sections/summary-data-sections.spec.js
+++ b/sandbox/test/_unit/example_app/sections/summary-data-sections.spec.js
@@ -21,6 +21,7 @@ describe('Apply Summary Data Sections', () => {
       const sectionFields = mappedSections.applicantsDetails;
       const expectedFields = [
         'name',
+        'otherNames',
         'dateOfBirth'
       ];
       const result = areOrderedEqual(sectionFields, expectedFields);
@@ -98,10 +99,10 @@ describe('Apply Summary Data Sections', () => {
 
   describe('Sections and Fields', () => {
     it('applicantsDetails', () => {
-      expect(containsAll(
-        Object.keys(fields),
-        mappedSections.applicantsDetails)
-      ).to.be.true;
+      mappedSections.applicantsDetails.every(i => {
+        const item = i.field || i;
+        expect(Object.keys(fields).includes(item)).to.be.true;
+      });
     });
 
     it('address', () => {

--- a/test/components/summary.spec.js
+++ b/test/components/summary.spec.js
@@ -78,7 +78,7 @@ describe('summary behaviour', () => {
         ],
         'other-names': [
           {
-            step: '/other-names',
+            step: '/name-details',
             field: 'otherNames',
             dependsOn: 'hasOtherNames',
             addElementSeparators: true
@@ -90,8 +90,8 @@ describe('summary behaviour', () => {
           { fields: ['brpNumber', 'dateOfBirth'] },
         '/has-other-names':
           { fields: ['hasOtherNames'] },
-        '/other-names':
-          { fields: ['otherNames'] },
+        '/name-details':
+          { fields: ['otherNames', 'otherFirstName', 'otherSurname'] },
         '/range-addresses':
           { fields: ['locationAddresses'] }
       }
@@ -105,8 +105,16 @@ describe('summary behaviour', () => {
     // other names values
     req.sessionModel.set('otherNames', {
       aggregatedValues: [
-        { itemTitle: 'Jane', fields: [{ field: 'firstName', value: 'Jane' }, { field: 'surname', value: 'Smith' }] },
-        { itemTitle: 'Steve', fields: [{ field: 'firstName', value: 'Steve' }, { field: 'surname', value: 'Adams' }] }
+        { itemTitle: 'Jane',
+          fields: [
+            { field: 'otherFirstName', value: 'Jane' },
+            { field: 'otherSurname', value: 'Smith' }
+          ]},
+        { itemTitle: 'Steve',
+          fields: [
+            { field: 'otherFirstName', value: 'Steve' },
+            { field: 'otherSurname', value: 'Adams' }
+          ]}
       ]
     });
     // location addresses Values
@@ -159,14 +167,14 @@ describe('summary behaviour', () => {
         {
           fields: [
             {
-              changeLinkDescription: 'A first name'
+              changeLinkDescription: 'Your other first name'
             }
           ]
         },
         {
           fields: [
             {
-              changeLinkDescription: 'A surname'
+              changeLinkDescription: 'Your other surname'
             }
           ]
         }
@@ -200,19 +208,19 @@ describe('summary behaviour', () => {
           section: 'Does the applicant have other names?',
           fields: [
             {
-              label: 'First name',
+              label: 'Your other first name',
               value: 'Jane',
-              changeLink: 'test/other-names/edit/0/firstName?returnToSummary=true'
+              changeLink: 'test/name-details/edit/0/otherFirstName?returnToSummary=true'
             },
             {
-              label: 'Surname',
+              label: 'Other surname',
               value: 'Smith',
-              changeLink: 'test/other-names/edit/0/surname?returnToSummary=true'
+              changeLink: 'test/name-details/edit/0/otherSurname?returnToSummary=true'
             },
             {
-              label: 'First name',
+              label: 'Your other first name',
               value: 'Steve',
-              changeLink: 'test/other-names/edit/1/firstName?returnToSummary=true'
+              changeLink: 'test/name-details/edit/1/otherFirstName?returnToSummary=true'
             }
           ]
         }]
@@ -254,7 +262,7 @@ describe('summary behaviour', () => {
                 itemTitle: 'John',
                 fields: [
                   {
-                    field: 'otherName',
+                    field: 'otherFirstName',
                     value: 'John'
                   }
                 ],
@@ -264,7 +272,7 @@ describe('summary behaviour', () => {
                 itemTitle: 'Jane',
                 fields: [
                   {
-                    field: 'otherName',
+                    field: 'otherFirstName',
                     value: 'Jane'
                   }
                 ],
@@ -272,26 +280,26 @@ describe('summary behaviour', () => {
               }
             ]
           },
-          step: '/other-names',
+          step: '/name-details',
           field: 'otherNames'
         };
 
       behaviour.expandAggregatedFields(inputObj, req)
         .should.be.eql([
           {
-            changeLinkDescription: 'Your other name',
-            label: 'Other name',
+            changeLinkDescription: 'Your other first name',
+            label: 'Your other first name',
             value: 'John',
-            changeLink: 'test/other-names/edit/0/otherName?returnToSummary=true',
-            field: 'otherName',
+            changeLink: 'test/name-details/edit/0/otherFirstName?returnToSummary=true',
+            field: 'otherFirstName',
             index: 0
           },
           {
-            changeLinkDescription: 'Your other name',
-            label: 'Other name',
+            changeLinkDescription: 'Your other first name',
+            label: 'Your other first name',
             value: 'Jane',
-            changeLink: 'test/other-names/edit/1/otherName?returnToSummary=true',
-            field: 'otherName',
+            changeLink: 'test/name-details/edit/1/otherFirstName?returnToSummary=true',
+            field: 'otherFirstName',
             index: 1
           }
         ]);
@@ -370,20 +378,20 @@ describe('summary behaviour', () => {
     it('should return the correct result for aggregated fields', () => {
       behaviour.getFieldData('otherNames', req).should.eql(
         {
-          changeLinkDescription: 'Your other names',
+          changeLinkDescription: 'Is known by other names',
           field: 'otherNames',
           label: 'Other names',
-          step: '/other-names',
+          step: '/name-details',
           value: {
             aggregatedValues: [
               {
                 fields: [
                   {
-                    field: 'firstName',
+                    field: 'otherFirstName',
                     value: 'Jane'
                   },
                   {
-                    field: 'surname',
+                    field: 'otherSurname',
                     value: 'Smith'
                   }
                 ],
@@ -392,11 +400,11 @@ describe('summary behaviour', () => {
               {
                 fields: [
                   {
-                    field: 'firstName',
+                    field: 'otherFirstName',
                     value: 'Steve'
                   },
                   {
-                    field: 'surname',
+                    field: 'otherSurname',
                     value: 'Adams'
                   }
                 ],
@@ -408,7 +416,6 @@ describe('summary behaviour', () => {
       );
     });
   });
-
   describe('#validate', () => {
     let rateLimiterStub;
     let yieldStub;

--- a/test/components/translations/en/default.json
+++ b/test/components/translations/en/default.json
@@ -3,13 +3,18 @@
     "has-other-names": {
       "header": "Have you been known by any other names?"
     },
+    "other-names": {
+      "header": "Does the applicant have other names?"
+     },
     "confirm": {
+      "fields": {
+        "otherNames": {
+          "label": "Other names"
+        }
+      },
       "sections": {
         "pdf-applicant-details": {
           "header": "Applicant’s details"
-        },
-        "other-names": {
-          "header": "Does the applicant have other names?"
         }
       }
     }
@@ -31,6 +36,9 @@
         }
       }
     },
+    "otherNames": {
+      "changeLinkDescription": "Is known by other names"
+    },
     "hasOtherNames": {
       "legend": "Have you been known by any other names?",
       "options": {
@@ -38,13 +46,13 @@
         "no": "No"
       }
     },
-    "otherName": {
-      "label": "Other name",
-      "changeLinkDescription": "Your other name"
+    "otherFirstName": {
+      "label": "Your other first name",
+      "changeLinkDescription": "Your other first name"
     },
-    "otherNames": {
-      "label": "Other names",
-      "changeLinkDescription": "Your other names"
+    "otherSurname": {
+      "label": "Other surname",
+      "changeLinkDescription": "Your other surname"
     },
     "brpNumber": {
       "label": "Biometric residence permit (BRP) number",


### PR DESCRIPTION
## What? 
Refactoring Items-Table use now summary list instead of table
## Why? 
as per ira ticket [HOFF-2045](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2045)
## How? 
code refactoring `items-table.html` in `frontend/template-partials/views/partials`
create a loop for `summary-name -list` in sandbox
## Testing?
run test and manual test in sandbox and PAF
update existing tests 
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
