### PR TITLE
HOFF-2051: Nunjucks Refactoring (Emailer Component)

### DIFF
--- a/components/emailer/email-service.js
+++ b/components/emailer/email-service.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const Hogan = require('hogan.js');
+const nunjucks = require('nunjucks');
 const debug = require('debug')('hof:emailer');
 
 const Emailer = require('./emailer');
@@ -43,7 +43,7 @@ module.exports = class EmailService {
         if (err) {
           reject(err);
         } else {
-          resolve(Hogan.compile(content.toString('utf8')));
+          resolve(nunjucks.compile(content.toString('utf8')));
         }
       });
     });

--- a/components/emailer/index.js
+++ b/components/emailer/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const EmailService = require('./email-service');
-const Hogan = require('hogan.js');
+const nunjucks = require('nunjucks');
 const fs = require('fs');
 const debug = require('debug')('hof:behaviour:emailer');
 
@@ -35,7 +35,7 @@ module.exports = config => {
 
         debug('Building email settings');
 
-        const settings = { body: Hogan.compile(template).render(data) };
+        const settings = { body: nunjucks.renderString(template, data) };
 
         if (typeof config.recipient === 'function') {
           settings.recipient = config.recipient(req.sessionModel.toJSON());

--- a/components/emailer/views/layout.html
+++ b/components/emailer/views/layout.html
@@ -4,22 +4,38 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
     <meta content="utf-8" http-equiv="encoding" />
     <!-- Use title if it's in the page YAML frontmatter -->
-    <title>{{subject}}</title>
+    <title>{{ subject }}</title>
   </head>
 
   <body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c">
-    <table width="100%" cellpadding="0" cellspacing="0" border="0">
-      <tr>
-        <td width="100%" height="53px" bgcolor="#0b0c0c">
-          <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
-            <tr>
-              <td width="100%" bgcolor="#0b0c0c" valign="middle">
-                <img width="152" height="31" src="cid:govuk_logotype_email" alt="GOV.UK" border="0" />
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse; width:100%" scaled-up="true">
+      <tbody>
+        <tr>
+          <td width="100%" height="60" style="background-color: #1d70b8 !important;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center" style="border-collapse:collapse; max-width:580px; width:100%">
+                <tbody>
+                  <tr>
+                    <td width="70" valign="bottom">
+                      <a href="https://www.gov.uk/" style="text-decoration:none; color:#fff">
+                        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse">
+                          <tbody>
+                            <tr>
+                              <td valign="bottom" height="60" class="x_logo__crown" style="font-size:28px; line-height:2; padding-left:10px">
+                                <img data-imagetype="External" src="https://static.notifications.service.gov.uk/images/govuk-logotype-tudor-crown.png" alt="" height="32" border="0" aria-hidden="true" style="margin-top:2px; max-height:32px">
+                              </td>
+                              <td valign="bottom" height="60" class="x_logo__text" style="font-size:28px; line-height:2.1428571429; padding-left:8px"><span aria-label="GOV.UK" style="font-family:Helvetica,Arial,'Noto Sans',sans-serif; font-weight:700; text-decoration:none; vertical-align:middle; display:inline-block">GOV<span class="x_logo__dot" style="font-family:Georgia,Times New Roman,Times,sans-serif; color:#00ffe0; display:inline-block; text-indent:0.04em; font-size:32px; line-height:1.35; vertical-align:top; margin-right:0.05em">.</span>UK</span>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
       <tr>
@@ -47,10 +63,10 @@
             <tr>
               <td style="font-family: Helvetica, Arial, sans-serif;">
                 <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">
-                  {{subject}}
+                  {{ subject }}
                 <p>
                 <div style="margin: 0 0 20px 0;">
-                  {{{body}}}
+                  {{ body | safe }}
                 </div>
               </td>
             </tr>

--- a/frontend/template-partials/views/email/data-row.html
+++ b/frontend/template-partials/views/email/data-row.html
@@ -1,4 +1,4 @@
 <tr style="border-top: 1px solid #009390;">
-  <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}email.fields.{{field}}{{/t}}</p></td>
-  <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0; white-space: pre-wrap;">{{value}}</p></td>
+  <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{ t("email.fields." + field.field) }}</p></td>
+  <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0; white-space: pre-wrap;">{{ field.value }}</p></td>
 </tr>

--- a/frontend/template-partials/views/email/formatted.html
+++ b/frontend/template-partials/views/email/formatted.html
@@ -1,12 +1,12 @@
-{{<email-layout}}
-  {{$email-content}}
-    {{#data}}
-      {{> email-section-row}}
-      {{#fields}}
-        {{#value}}
-          {{> email-data-row}}
-        {{/value}}
-      {{/fields}}
-    {{/data}}
-  {{/email-content}}
-{{/email-layout}}
+{% extends "email/layout.html" %}
+  {% block emailContent %}
+    {% if data %}
+      {% include "email/section-row.html" %}
+      {% for field in fields}
+        {% if field.value %}
+          {% set field = field %}
+          {% include "email/data-row.html" %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endblock %}

--- a/frontend/template-partials/views/email/layout.html
+++ b/frontend/template-partials/views/email/layout.html
@@ -4,22 +4,38 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
     <meta content="utf-8" http-equiv="encoding" />
     <!-- Use title if it's in the page YAML frontmatter -->
-    <title>{{#t}}email.information.subject{{/t}}</title>
+    <title>{{ t("email.information.subject") }}</title>
   </head>
 
   <body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c">
-    <table width="100%" cellpadding="0" cellspacing="0" border="0">
-      <tr>
-        <td width="100%" height="53px" bgcolor="#0b0c0c">
-          <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
-            <tr>
-              <td width="100%" bgcolor="#0b0c0c" valign="middle">
-                <img width="152" height="31" src="cid:govuk_logotype_email" alt="GOV.UK" border="0" />
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse; width:100%" scaled-up="true">
+      <tbody>
+        <tr>
+          <td width="100%" height="60" style="background-color: #1d70b8 !important;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center" style="border-collapse:collapse; max-width:580px; width:100%">
+                <tbody>
+                  <tr>
+                    <td width="70" valign="bottom">
+                      <a href="https://www.gov.uk/" style="text-decoration:none; color:#fff">
+                        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse">
+                          <tbody>
+                            <tr>
+                              <td valign="bottom" height="60" class="x_logo__crown" style="font-size:28px; line-height:2; padding-left:10px">
+                                <img data-imagetype="External" src="https://static.notifications.service.gov.uk/images/govuk-logotype-tudor-crown.png" alt="" height="32" border="0" aria-hidden="true" style="margin-top:2px; max-height:32px">
+                              </td>
+                              <td valign="bottom" height="60" class="x_logo__text" style="font-size:28px; line-height:2.1428571429; padding-left:8px"><span aria-label="GOV.UK" style="font-family:Helvetica,Arial,'Noto Sans',sans-serif; font-weight:700; text-decoration:none; vertical-align:middle; display:inline-block">GOV<span class="x_logo__dot" style="font-family:Georgia,Times New Roman,Times,sans-serif; color:#00ffe0; display:inline-block; text-indent:0.04em; font-size:32px; line-height:1.35; vertical-align:top; margin-right:0.05em">.</span>UK</span>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
       <tr>
@@ -47,10 +63,10 @@
             </tr>
             <tr>
               <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
-                <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">{{#t}}email.information.subject{{/t}}</p>
-                <p style="font-size: 16px; font-weight: normal; color: #000; line-height: 1.32; margin: 0 0 10px 0;">{{#t}}email.content.{{recipient}}-intro{{/t}}</p>
+                <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">{{ t("email.information.subject") }}</p>
+                <p style="font-size: 16px; font-weight: normal; color: #000; line-height: 1.32; margin: 0 0 10px 0;">{{ t("email.content." + recipient + "-intro") }}</p>
                 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
-                  {{$email-content}}{{/email-content}}
+                  {% block emailContent %}{% endblock %}
                 </table>
               </td>
             </tr>

--- a/frontend/template-partials/views/email/raw.html
+++ b/frontend/template-partials/views/email/raw.html
@@ -1,11 +1,11 @@
-{{#t}}email.information.subject{{/t}}
-{{#t}}email.content.{{recipient}}-intro{{/t}}
-{{#t}}email.information.enquiry{{/t}}
-{{#data}}
-  {{#t}}pages.{{section}}.header{{/t}}
-  {{#fields}}
-    {{#value}}
-      {{#t}}email.fields.{{field}}{{/t}}: {{value}}
-    {{/value}}
-  {{/fields}}
-{{/data}}
+{{ t("email.information.subject") }}
+{{ t("email.content." +  recipient + "-intro") }}
+{{ t("email.information.enquiry") }}
+{% if data %}
+  {{ t("pages." + section + ".header") }}
+  {% for field in fields %}
+    {% if field.value %}
+      {{ t("email.fields." + field.field) }}: {{ field.value }}
+    {% endif %}
+  {% endfor %}
+{% endif %}

--- a/frontend/template-partials/views/email/section-row.html
+++ b/frontend/template-partials/views/email/section-row.html
@@ -1,3 +1,3 @@
 <tr style="border-top: 1px solid #009390;">
-  <td width="100%" colspan="2"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#t}}pages.{{section}}.header{{/t}}</p></td>
+  <td width="100%" colspan="2"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{ t("pages." + section + ".header") }}</p></td>
 </tr>


### PR DESCRIPTION
## What? 
[HOFF-2051](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2051) - Nunjucks Refactoring (Emailer Component)
## Why? 
part of nunjucks refactoring
## How? 
- convert email template views to nunjucks format
- replace hogan with nunjucks in email-service.js and emailer/index.js
- use govuk rebrand styling
## Testing?
no hof services use the emailer component directly from hof but BRP uses the same set up and have tested the views and functionality locally on BRP.
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
