### PR TITLE
HOFF-2024: Nunjucks Refactoring and Govuk Frontend Update (improvements) - change use of deprecated 'visuallyhidden' class to 'govuk-visually-hidden' class

### DIFF
--- a/components/combine-and-loop-fields/index.js
+++ b/components/combine-and-loop-fields/index.js
@@ -86,7 +86,7 @@ module.exports = config => {
           'yes', 'no'
         ],
         legend: {
-          className: 'visuallyhidden'
+          className: 'govuk-visually-hidden'
         }
       }, req.form.options.fieldSettings);
 

--- a/frontend/template-mixins/partials/forms/checkbox.html
+++ b/frontend/template-mixins/partials/forms/checkbox.html
@@ -13,7 +13,7 @@
       <label for="{{ key }}"
         class="{% if className %}{{ className }} {% endif %}{% if invalid %}invalid-input{% endif %}">
         {{ label | safe }}
-        {% if error %}<span class="visuallyhidden">{{ error.message }}</span>{% endif %}
+        {% if error %}<span class="govuk-visually-hidden">{{ error.message }}</span>{% endif %}
       </label>
       {% if hint %}
       <div id="{{ key }}-hint" class="govuk-hint govuk-checkboxes__hint">

--- a/sandbox/apps/sandbox/fields.js
+++ b/sandbox/apps/sandbox/fields.js
@@ -32,7 +32,7 @@ module.exports = {
   },
   street: {
     validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
-    labelClassName: 'visuallyhidden'
+    labelClassName: 'govuk-visually-hidden'
   },
   townOrCity: {
     validate: ['required', 'notUrl',
@@ -47,7 +47,7 @@ module.exports = {
   incomeTypes: {
     isPageHeading: 'true',
     mixin: 'checkboxGroup',
-    labelClassName: 'visuallyhidden',
+    labelClassName: 'govuk-visually-hidden',
     validate: ['required'],
     options: [
       'salary',
@@ -75,7 +75,7 @@ module.exports = {
   },
   'int-phone-number': {
     validate: ['required'],
-    labelClassName: 'visuallyhidden'
+    labelClassName: 'govuk-visually-hidden'
   },
   countrySelect: {
     mixin: 'select',
@@ -83,7 +83,7 @@ module.exports = {
     className: ['typeahead'],
     options:[''].concat(require('homeoffice-countries').allCountries),
     legend: {
-      className: 'visuallyhidden'
+      className: 'govuk-visually-hidden'
     },
     validate: ['required']
   },

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -287,7 +287,7 @@ describe('Template Mixins', () => {
       it('adds a `labelClassName` when set in field options', () => {
         res.locals.options.fields = {
           'field-name': {
-            labelClassName: 'visuallyhidden'
+            labelClassName: 'govuk-visually-hidden'
           }
         };
         middleware(req, res, next);
@@ -295,7 +295,7 @@ describe('Template Mixins', () => {
         expect(renderSpy).toHaveBeenCalledWith(
           expect.any(String),
           expect.objectContaining({
-            labelClassName: 'visuallyhidden'
+            labelClassName: 'govuk-visually-hidden'
           })
         );
       });
@@ -330,7 +330,7 @@ describe('Template Mixins', () => {
       it('overrides `formGroupClassName` when set in field options', () => {
         res.locals.options.fields = {
           'field-name': {
-            formGroupClassName: 'visuallyhidden'
+            formGroupClassName: 'govuk-visually-hidden'
           }
         };
         middleware(req, res, next);
@@ -338,7 +338,7 @@ describe('Template Mixins', () => {
         expect(renderSpy).toHaveBeenCalledWith(
           expect.any(String),
           expect.objectContaining({
-            formGroupClassName: 'visuallyhidden'
+            formGroupClassName: 'govuk-visually-hidden'
           })
         );
       });
@@ -380,11 +380,11 @@ describe('Template Mixins', () => {
         );
       });
 
-      it('allows configuration of a non-required input with a visuallyhidden label', () => {
+      it('allows configuration of a non-required input with a govuk-visually-hidden label', () => {
         res.locals.options.fields = {
           'field-name': {
             required: false,
-            labelClassName: 'visuallyhidden'
+            labelClassName: 'govuk-visually-hidden'
           }
         };
         middleware(req, res, next);
@@ -393,7 +393,7 @@ describe('Template Mixins', () => {
           expect.any(String),
           expect.objectContaining({
             required: false,
-            labelClassName: 'visuallyhidden'
+            labelClassName: 'govuk-visually-hidden'
           })
         );
       });
@@ -1117,7 +1117,7 @@ describe('Template Mixins', () => {
       it('adds `labelClassName` to existing default classes when set in field options', () => {
         res.locals.options.fields = {
           'field-name': {
-            labelClassName: 'visuallyhidden'
+            labelClassName: 'govuk-visually-hidden'
           }
         };
         middleware(req, res, next);
@@ -1125,7 +1125,7 @@ describe('Template Mixins', () => {
         expect(renderSpy).toHaveBeenCalledWith(
           expect.any(String),
           expect.objectContaining({
-            labelClassName: 'visuallyhidden'
+            labelClassName: 'govuk-visually-hidden'
           }));
       });
 
@@ -1668,7 +1668,7 @@ describe('Template Mixins', () => {
       it('adds `labelClassName` to the default class when set in field options', () => {
         res.locals.options.fields = {
           'field-name': {
-            labelClassName: 'visuallyhidden'
+            labelClassName: 'govuk-visually-hidden'
           }
         };
         middleware(req, res, next);
@@ -1676,7 +1676,7 @@ describe('Template Mixins', () => {
         expect(renderSpy).toHaveBeenCalledWith(
           expect.any(String),
           expect.objectContaining({
-            labelClassName: 'visuallyhidden'
+            labelClassName: 'govuk-visually-hidden'
           }));
       });
 


### PR DESCRIPTION
## What? 
- Change use of deprecated `visuallyhidden` class to `govuk-visually-hidden` class
## Why?  
Part of nunjucks refactoring and govuk frontend update work - [HOFF-2024](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2024). The correct class name to use to stop elements from being displayed on the page and keep their contents available to screen readers is `govuk-visually-hidden`.  the `visuallyhidden` class is from the deprecated govuk frontend toolkit which has been removed from hof. The 'visuallyhidden' styling still exists as a fallback helper for backwards compatibility to ease migration but the correct usage is the govuk class so classes have been updated to use that.
## How? 
- update `visuallyhidden` classes `govuk-visually-hidden` to  where in files where it is being used
## Testing?
tested locally in sandbox
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
