### PR TITLE
HOFF-2024: Nunjucks Refactoring and Govuk Frontend update(bug fix) - Date and grouped inputs form focus in edit mode

### DIFF
--- a/frontend/themes/gov-uk/client-js/form-focus.js
+++ b/frontend/themes/gov-uk/client-js/form-focus.js
@@ -1,0 +1,25 @@
+/**
+ * This module adds the yellow focus border to:
+ *   * day field of date input when selected from a summary page edit link
+ *   * amount field of grouped inputs when selected from a summary page edit link
+ **/
+
+'use strict';
+
+function formFocus() {
+  const forms = document.getElementsByTagName('form');
+  const getElementFromSummaryLink = window.location.hash.replace(/^#/, '');
+  const getEditPath = window.location.pathname.split('/').pop();
+
+  const editMode = getElementFromSummaryLink && getEditPath === 'edit';
+
+  if (document.getElementById(getElementFromSummaryLink + '-day') && forms.length === 1 && editMode) {
+    document.getElementById(getElementFromSummaryLink + '-day').focus();
+  }
+
+  if (document.getElementById(getElementFromSummaryLink + '-amount') && forms.length === 1 && editMode) {
+    document.getElementById(getElementFromSummaryLink + '-amount').focus();
+  }
+}
+
+module.exports = formFocus;

--- a/frontend/themes/gov-uk/client-js/index.js
+++ b/frontend/themes/gov-uk/client-js/index.js
@@ -10,7 +10,9 @@ var skipToMain = require('./skip-to-main');
 var cookie = require('./govuk-cookies');
 var cookieSettings = require('./cookieSettings');
 var sessionDialog = require('./session-timeout-dialog');
+var formFocus = require('./form-focus');
 
+helpers.documentReady(formFocus);
 helpers.documentReady(cookieSettings.initialiseCookieBanner);
 helpers.documentReady(cookieSettings.initialiseCookiePage);
 helpers.documentReady(cookieSettings.onLoad);

--- a/test/frontend/jest/formFocus.test.js
+++ b/test/frontend/jest/formFocus.test.js
@@ -1,0 +1,94 @@
+/* eslint-disable max-len */
+const formFocus = require('../../../frontend/themes/gov-uk/client-js/form-focus');
+
+describe('formFocus', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('focuses the date day input when in edit mode', () => {
+    document.body.innerHTML = `
+    <form>
+      <div id="dateOfBirth" class="govuk-date-input">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" role="group">
+            <div class="govuk-date-input">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="dateOfBirth-day">
+                    Day
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dateOfBirth-day" name="dateOfBirth-day" type="text" inputmode="numeric" autocomplete="bday-day" min="1" max="12" maxlength="2">
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="dateOfBirth-month">
+                    Month
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dateOfBirth-month" name="dateOfBirth-month" type="text" inputmode="numeric" autocomplete="bday-month" min="1" max="12" maxlength="2">
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="dateOfBirth-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="dateOfBirth-year" name="dateOfBirth-year" type="text" inputmode="numeric" autocomplete="bday-year" maxlength="4">
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </form>
+    `;
+    window.history.pushState({}, '', '/test/edit#dateOfBirth');
+
+    const dayInput = document.getElementById('dateOfBirth-day');
+    const focusSpy = jest.spyOn(dayInput, 'focus');
+
+    formFocus();
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('focuses the grouped amount input when in edit mode', () => {
+    document.body.innerHTML = `
+    <form>
+      <div id="amountWithUnitSelect" class="govuk-amount-with-unit-select-input">
+        <div class="grouped-inputs__item"> 
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="amountWithUnitSelect-amount">
+              Amount:
+            </label>
+            <div class="govuk-input__wrapper">
+              <input class="govuk-input govuk-input--width-3" id="amountWithUnitSelect-amount" name="amountWithUnitSelect-amount" type="text" autocomplete="off" aria-required="false">
+            </div>
+          </div>
+        </div>
+        <div class="grouped-inputs__item">
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="amountWithUnitSelect-unit">
+              Unit:
+            </label>
+            <select class="govuk-select" id="amountWithUnitSelect-unit" name="amountWithUnitSelect-unit" aria-required="false">
+              <option value="">Select...</option>
+              <option value="L">Litres</option>
+              <option value="KG">Kilograms</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </form>
+    `;
+    window.history.pushState({}, '', '/test/edit#amountWithUnitSelect');
+
+    const amountInput = document.getElementById('amountWithUnitSelect-amount');
+    const focusSpy = jest.spyOn(amountInput, 'focus');
+
+    formFocus();
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What? 
Fix day field for date input and amount field for grouped inputs not being highlighted when change link is clicked
## Why? 
When clicking a change link for dates or grouped inputs the first field was not highlighted. Form focus for date inputs and grouped inputs when clicking their respective change links  was customized functionality that was added into the now deprecated and removed frontend/toolkit. When the frontend/toolkit was removed as part of the nunjucks refactoring and govuk frontend update work - [HOFF-2042](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2042), this functionality no longer worked. 
I have restored the part of the form focus functionality that relates to date inputs and grouped inputs when clicking their change links.
## How? 
- restore form focus functionality for date and grouped inputs field when in edit mode
- add test for form focus
## Testing?
tested locally in sandbox and in gro
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
