### PR TITLE
HOFF-2085: Bug fix - some service level views not overriding framework views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1760,7 +1760,7 @@ renderField
 This mixin takes a `key=value` query string and returns a query string with the extra params appended. If the key is already present in the query string, the value passed to the mixin is used
 
 ```html
-<a href="{% qs %}key=value{% endif %}">Click to append query</a>
+<a href="{{ qs('key=value') }}">Click to append query</a>
 ```
 
 ### renderField

--- a/frontend/template-mixins/mixins/template-mixins.js
+++ b/frontend/template-mixins/mixins/template-mixins.js
@@ -94,8 +94,7 @@ module.exports = function (options) {
 
     // use nunjucks environment for resolving includes/partials from the
     // project's views roots for this request.
-    const nunjucksEnv = (req && req.app && req.app.locals && req.app.locals.nunjucksEnv);
-
+    const nunjucksEnv = req?.res?.locals?.nunjucksEnv;
 
     // helper: resolve a template file path by trying express View, configured viewsDirectory and app roots
     function resolveTemplateFile(name) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -60,6 +60,11 @@ module.exports = config => {
 
   app.use(expressPartialTemplates(app));
 
+  app.use((req, res, next) => {
+    res.locals.routeConfig = config.route;
+    next();
+  });
+
   app.use(translate({
     resources: config.theme.translations,
     path: paths.translations + '/__lng__/__ns__.json'

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
 const nunjucks = require('nunjucks');
@@ -37,7 +36,10 @@ module.exports = async (app, config) => {
   app.enable('view cache');
 
   if (config.views) {
-    const viewsArray = _.castArray(config.views);
+    const viewsArray = Array.isArray(config.views)
+      ? config.views
+      : [config.views];
+
     viewsArray.slice().reverse().forEach(view => {
       const customViewPath = path.resolve(config.root, view);
       try {
@@ -52,67 +54,154 @@ module.exports = async (app, config) => {
   app.set('views', viewPaths);
   app.use(expressPartialTemplates(app));
 
-  const nunjucksRoots = [];
-
-  // add the app views to the Nunjucks roots, so that the resolved path can be found by the Nunjucks loader
-  const findAppViewPaths = rootDir => {
-    const results = [];
-    // avoid checking 'node modules'
-    const IGNORE_DIRS = new Set(['node_modules']);
-    const addDir = dir => {
-      const entries = fs.readdirSync(dir, { withFileTypes: true });
-      for (const entry of entries) {
-        if (IGNORE_DIRS.has(entry.name)) continue;
-        const fullPath = path.join(dir, entry.name);
-
-        if (entry.isDirectory()) {
-          if (entry.name === 'views') {
-            results.push(fullPath);
-          } else {
-            addDir(fullPath);
-          }
-        }
-      }
-    };
-
-    addDir(rootDir);
-    return results;
-  };
-
-  const appViewPaths = findAppViewPaths(config.root);
-
-  nunjucksRoots.push(...viewPaths, ...appViewPaths);
-
-  try {
-    const govukPkg = require.resolve('govuk-frontend/package.json', { paths: [config.root || process.cwd()] });
-    const govukRoot = path.dirname(govukPkg);
-    nunjucksRoots.push(govukRoot);
-    nunjucksRoots.push(path.join(govukRoot, 'dist'));
-  } catch (e) {
-    /* eslint-disable-next-line no-console */
-    console.debug('govuk-frontend not resolved via require.resolve; ensure package is installed if needed');
-  }
-
-  // dedupe and keep only existing directories
-  const uniqueRoots = Array.from(new Set(nunjucksRoots)).filter(p => {
-    try { return fs.existsSync(p) && fs.lstatSync(p).isDirectory(); } catch (e) { return false; }
-  });
-
   const isLocalDev = process.env.NODE_ENV === 'local';
 
-  // configure nunjucks and keep the env for other modules if needed
-  const nunjucksEnv = nunjucks.configure(uniqueRoots, {
-    autoescape: true,
-    express: app,
-    watch: isLocalDev,
-    noCache: isLocalDev
+  const govukPkg = require.resolve('govuk-frontend/package.json', {
+    paths: [config.root || process.cwd()]
+  });
+  const govukRoot = path.dirname(govukPkg);
+
+  const envCache = new Map();
+
+  const absoluteViewPath = viewPath => {
+    return path.isAbsolute(viewPath)
+      ? viewPath
+      : path.resolve(config.root || process.cwd(), viewPath);
+  };
+
+  const getRouteViewPaths = route => {
+    if (!route) {
+      return [];
+    }
+
+    if (route.views) {
+      return (Array.isArray(route.views) ? route.views : [route.views])
+        .filter(Boolean)
+        .map(absoluteViewPath);
+    }
+
+    if (route.name) {
+      return [path.resolve(config.root || process.cwd(), 'apps', route.name, 'views')];
+    }
+
+    return [];
+  };
+
+  const matchBaseUrlRoute = (url, routes) => {
+    return routes.find(r =>
+      r.baseUrl &&
+      (
+        url === r.baseUrl ||
+        url.startsWith(r.baseUrl + '/')
+      )
+    );
+  };
+
+  const matchRootRoute = (url, routes) => {
+    const segments = url.split('/').filter(Boolean);
+
+    if (!segments.length) return null;
+
+    const first = `/${segments[0]}`;
+
+    return routes.find(r =>
+      !r.baseUrl &&
+      (
+        (r.steps && r.steps[first]) ||
+        (r.pages && r.pages[first])
+      )
+    );
+  };
+
+  const matchRoute = (req, routes) => {
+    if (!req || !routes) {
+      return null;
+    }
+
+    if (req.baseUrl) {
+      const baseUrlRoute = routes.find(r => r.baseUrl && r.baseUrl === req.baseUrl);
+      if (baseUrlRoute) {
+        return baseUrlRoute;
+      }
+    }
+
+    const url = (req.originalUrl || req.url || req.path || '').split('?')[0];
+
+    const baseUrlMatch = matchBaseUrlRoute(url, routes);
+    if (baseUrlMatch) return baseUrlMatch;
+
+    const rootMatch = matchRootRoute(url, routes);
+    if (rootMatch) return rootMatch;
+
+    return null;
+  };
+
+  function getEnvForRoute(route) {
+    const routeViews = getRouteViewPaths(route);
+    const key = routeViews.length ? routeViews.join('|') : 'common';
+
+    if (envCache.has(key)) {
+      return envCache.get(key);
+    }
+
+    const paths = [];
+
+    paths.push(...routeViews);
+    paths.push(path.join(config.root || process.cwd(), 'apps/common/views'));
+    paths.push(...viewPaths);
+    paths.push(govukRoot);
+    paths.push(path.join(govukRoot, 'dist'));
+
+    // dedupe and keep only existing directories
+    const uniquePaths = Array.from(new Set(paths)).filter(viewPath => {
+      try {
+        return fs.existsSync(viewPath) && fs.lstatSync(viewPath).isDirectory();
+      } catch (e) {
+        return false;
+      }
+    });
+
+    const loader = new nunjucks.FileSystemLoader(uniquePaths, {
+      noCache: isLocalDev
+    });
+
+    const env = new nunjucks.Environment(loader, {
+      autoescape: true,
+      watch: isLocalDev,
+      noCache: isLocalDev
+    });
+
+    envCache.set(key, env);
+    return env;
+  }
+
+  app.use((req, res, next) => {
+    res.locals.req = req;
+    const matchedRoute = matchRoute(req, config.routes);
+    res.locals.nunjucksEnv = getEnvForRoute(res.locals.routeConfig || matchedRoute);
+    next();
   });
 
-  // expose the same env so other modules/middlewares can reuse it
-  app.locals.nunjucksEnv = nunjucksEnv;
-
   app.set('view engine', viewEngine);
-  app.engine(viewEngine, nunjucksEnv.render.bind(nunjucksEnv));
+  app.engine(viewEngine, (filePath, context, callback) => {
+    const req = context && context.req;
+    let env = context && context.nunjucksEnv;
+
+    if (context && context.routeConfig) {
+      env = getEnvForRoute(context.routeConfig);
+      app.locals.nunjucksEnv = env;
+    } else if (!env && req) {
+      const matchedRoute = matchRoute(req, config.routes);
+      env = getEnvForRoute(matchedRoute);
+      app.locals.nunjucksEnv = env;
+    }
+
+    if (!env) {
+      env = app.locals.nunjucksEnv || getEnvForRoute(null);
+    }
+
+    env.render(filePath, context, callback);
+  });
 
   app.use(bodyParser.urlencoded({
     extended: true

--- a/test/frontend/mixins.test.js
+++ b/test/frontend/mixins.test.js
@@ -34,9 +34,11 @@ describe('Template Mixins', () => {
       locals: {
         options: {
           fields: {}
-        }
+        },
+        nunjucksEnv
       }
     };
+    req.res = res;
 
     next = jest.fn();
 


### PR DESCRIPTION
## What? 
[HOFF-2085](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-2085) - fix bug where some service level views not overriding framework views
## Why? 
When an service uses a custom view to override the default framework equivalent e.g. layout.html, the framework view is still being used. This happens for views that are not associated with a step e.g. layout.html, page.html. A custom confirmation.html view for the '/confirmation' step correctly overrides the framework default. 
## How? 
- refactored the lib/settings.js file so that view precedence is `service level <route>/views -> service level common/views -> hof template-partials/views` to allow services to override equivalent framework views correctly
-  set res.locals.routeConfig in lib/router.js so it can be used in lib/settings.js
- updated how template-mixins.js and mixins test call nunjucks environment after changes to lib/settings
## Testing?
tested locally in hof/sandbox and  locally in paf using beta version 24.0.0-nunjucks-refactoring-fix-view-override-bug.beta.12
## Screenshots (optional)
## Anything Else? (optional)
- fixed incorrect syntax in readme
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
