### PR TITLE
build: adding customised dependabot config to ensure both package and lock are updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    versioning-strategy: increase
+    schedule:
+      interval: weekly
+      time: "06:00"
+      day: "monday"
+      timezone: "Europe/London"
+    target-branch: "master"    
+    labels:
+      - dependencies
+    commit-message:
+      prefix: deps
+    pull-request-branch-name:
+      separator: "-"
+    rebase-strategy: auto
+    groups:
+      patch-and-minor:
+        update-types:
+          - patch
+          - minor

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,6 +6,8 @@
 ## Anything Else? (optional)
 ## Check list
 
+Dependabot PRs: JIRA branch/commit checklist items below do not apply to bot-generated dependency update pull requests.
+
 - [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
 - [ ] I have written tests (if relevant)
 - [ ] I have created a JIRA number for my branch


### PR DESCRIPTION
## What? 

This PR introduces customised dependabot config for HOF, allowing the automated dependabot tool to create PR's to update dependencies where updates are available.

## Why? 

The default dependabot workflow only updates the `.lock` file and not the `package.json` meaning changes would get lost/reverted when any manual PR's are raised for other changes.

## How? 

Adds a custom dependabot config file which will be picked up when manually refreshing dependabot alerts and when run on the weekly schedule. 

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [X] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [X] Ensure workflow jobs are passing especially tests
- [X] I will squash the commits before merging
