### PR TITLE
[MINOR] fix: moving vite back to dependencies as hof-build requires it

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,8 +89,9 @@
     "uglify-js": "^3.19.3",
     "underscore": "^1.13.7",
     "urijs": "^1.19.11",
-    "uuid": "^11.1.1",
-    "winston": "^3.18.3"
+    "uuid": "^11.1.1",    
+    "winston": "^3.18.3",
+    "vite": "^7.3.5"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^7.3.2",
@@ -124,7 +125,6 @@
     "sinon-chai": "^3.7.0",
     "supertest": "^3.4.2",
     "travis-conditions": "0.0.0",
-    "vite": "^7.3.5",
     "vitest": "^4.0.8",
     "watchify": "^4.0.0",
     "webdriverio": "^5.0.0"


### PR DESCRIPTION
## What? 

Moving vite back into dependencies.

## Why? 

Despite vite typically only being needed in `devDependencies`, the hof build process requires it during the post-install phase, which mean as a `devDependency` each service using hof would need to add `vite` to their own package.

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

Dependabot PRs: JIRA branch/commit checklist items below do not apply to bot-generated dependency update pull requests.

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [ ] I will squash the commits before merging
