### PR TITLE
[MINOR]: pinning form-data to v4.0.6 to bring in line with axios requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "exit": "true"
   },
   "resolutions": {
-    "form-data": "^2.5.6",
+    "form-data": "^4.0.6",
     "js-yaml": "^4.2.0",
     "qs": "^6.14.1",
     "serialize-javascript": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5263,17 +5263,16 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
-form-data@^2.3.1, form-data@^2.5.5, form-data@^2.5.6, form-data@^4.0.5, form-data@~2.3.2:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.6.tgz#ef39b3d99e2fc9f25420c0db7962fe36cafcd244"
-  integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
+form-data@^2.3.1, form-data@^2.5.5, form-data@^4.0.5, form-data@^4.0.6, form-data@~2.3.2:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.4"
     mime-types "^2.1.35"
-    safe-buffer "^5.2.1"
 
 formidable@^1.2.0:
   version "1.2.6"


### PR DESCRIPTION
# What? 

Pin form-data to 4.0.6 in resolutions to bring in line with axios requirement.

## Why? 

Previous release had downgraded it to v2.

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

Dependabot PRs: JIRA branch/commit checklist items below do not apply to bot-generated dependency update pull requests.

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [ ] I will squash the commits before merging
