### PR TITLE
HOFF-2107: Nunjucks Refactoring (improvements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1911,8 +1911,8 @@ In your view file:
 {{ detailsComponent(details) }}
 
 {# Set Override arguments - optional #}
-{% set overrideSummary = t('pages.test-page.details.custom-summary') %} {# This can also be an ordinary string #}
-{% set overrideText = t('pages.test-page.details.custom-text') %} {# This can also be an ordinary string #}
+{% set overrideSummary = t('pages.test-page.details.custom-summary') %} {# This can also be an ordinary string or html #}
+{% set overrideText = t('pages.test-page.details.custom-text') %} {# This can also be an ordinary string or html #}
 
 {# Override just default summary #}
 {{ detailsComponent(details, overrideSummary) }}

--- a/frontend/template-partials/views/partials/details-summary.njk
+++ b/frontend/template-partials/views/partials/details-summary.njk
@@ -1,11 +1,11 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% macro detailsComponent(details, customSummary=null, customText=null) %}
-  {% set summaryText = customSummary or details.summary or '' %}
-  {% set text = customText or details.text or '' %}
+  {% set summaryHtml = customSummary or details.summary or '' %}
+  {% set html = customText or details.text or '' %}
 
   {{ govukDetails({
-    summaryText: summaryText,
-    text: text
+    summaryHtml: summaryHtml,
+    html: html
   }) }}
 {% endmacro %}


### PR DESCRIPTION
Relates HOFF-2107

- allows HTML to be used in details component to prevent escaping HTML e.g. table in Appeal Rights Exhausted (ARE)
- amend the govukDetails component to use 'summaryHtml' and 'html' options instead of 'summaryText' and 'text' options to allow both text and html instead of just text.
- update readme

## What? 
## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

Dependabot PRs: JIRA branch/commit checklist items below do not apply to bot-generated dependency update pull requests.

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [ ] I will squash the commits before merging
