### PR TITLE
[MINOR] - Vite build task gets output location from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Each task (except Vite) has a common configuration format with the following opt
 - `match` - defines the pattern for files to watch to trigger a rebuild of this task
 - `restart` - defines if this task should result in a server restart
 
+For Vite, the following configuration can be specified:
+- `outDir` - Specifies the output directory (relative to project root). Only changes only the build output location, does not change runtime static mounting.
+Example from hof settings:
+```js
+  "js": {
+    "outDir": './dist/public'
+  }
+```
+
+
 Additionally the server instance created by `watch` can be configured by setting `server` config. Available options are:
 
 - `cmd` - defines the command used to start the server

--- a/build/tasks/vite/index.js
+++ b/build/tasks/vite/index.js
@@ -7,18 +7,23 @@ const hofDefaults = require('../../../config/hof-defaults');
 
 module.exports = config => {
   process.env.NODE_ENV = hofDefaults.env;
+  const publicDirectory = path.resolve(process.cwd(), config.js.outDir || 'public');
 
   if(!config.production) {
     return vite.build({
       configFile: viteConfig,
       mode: 'development',
       build: {
-        sourcemap: config.js.sourceMaps
+        sourcemap: config.js.sourceMaps,
+        outDir: publicDirectory
       }
     });
   }
   return vite.build({
-    configFile: viteConfig
+    configFile: viteConfig,
+    build: {
+        outDir: publicDirectory
+      }
   });
 };
 module.exports.task = 'vite';

--- a/build/tasks/vite/index.js
+++ b/build/tasks/vite/index.js
@@ -22,8 +22,8 @@ module.exports = config => {
   return vite.build({
     configFile: viteConfig,
     build: {
-        outDir: publicDirectory
-      }
+      outDir: publicDirectory
+    }
   });
 };
 module.exports.task = 'vite';

--- a/build/tasks/vite/vite.config.js
+++ b/build/tasks/vite/vite.config.js
@@ -7,7 +7,6 @@ import fs from 'fs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-const publicDirectory = resolve(process.cwd(), 'public');
 const entryFile = (() => {
   const src = resolve(process.cwd(), 'assets/js/index.js');
   if (fs.existsSync(src)) return src;
@@ -49,7 +48,6 @@ export default defineConfig({
   base: '/assets/',
   publicDir: 'static', // static files copied as-is
   build: {
-    outDir: publicDirectory,
     emptyOutDir: false,
     sourcemap: false,
     rollupOptions: {

--- a/config/builder-defaults.js
+++ b/config/builder-defaults.js
@@ -15,7 +15,8 @@ module.exports = {
     sourceMaps: false
   },
   js: {
-    sourceMaps: false
+    sourceMaps: false,
+    outDir: 'public'
   },
   translate: {
     src: 'apps/**/translations/src',


### PR DESCRIPTION
## What? 
Add the ability to configure the output directory for JavaScript bundle.

## Why?
SAI and Further Subs projects are currently configuring the output directory for JS bundle and this functionality has been removed from newer versions of HOF, so we can not upgrade to new HOF versions.

## How? 
Add config option to builder defaults and pass configuration to Vite build task.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

Dependabot PRs: JIRA branch/commit checklist items below do not apply to bot-generated dependency update pull requests.

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure workflow jobs are passing especially tests
- [ ] I will squash the commits before merging
