### PR TITLE
HOFF-2142 Include GA directives on GA4 tag present and add test for GA4 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2026-07-01 Verseion 24.4.0 (Stable), @meganjohnHO
+
+### Changed
+- Google Analytics domains now added into CSP on presence of `ga4TagId` or `gaTagId` (previously only on `gaTagId`).
+
 ## 2026-06-17, Version 24.0.0 (Stable), @gregwolversonHO, @nzorba
 
 ⚠️ Major release which removes nodemailer dependency and email functionality

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ const getContentSecurityPolicy = (config, res) => {
     manifestSrc: ["'self'"]
   };
 
-  if (config.gaTagId) {
+  if (config.gaTagId || config.ga4TagId) {
     directives.styleSrc = directives.styleSrc.concat(gaDirectives.styleSrc);
     directives.scriptSrc = directives.scriptSrc.concat(gaDirectives.scriptSrc);
     directives.fontSrc = directives.fontSrc.concat(gaDirectives.fontSrc);

--- a/test/integration/server.spec.js
+++ b/test/integration/server.spec.js
@@ -501,6 +501,32 @@ describe('hof server', () => {
           csp['connect-src'].should.include('https://region1.analytics.google.com');
         });
     });
+
+    it('CSP extends with google directives if ga4TagId set', () => {
+      const bs = bootstrap({
+        csp: {},
+        fields: 'fields',
+        gaTagId: '',
+        ga4TagId: 'G-1234ABC',
+        routes: [{
+          views: `${root}/apps/app_1/views`,
+          steps: {
+            '/one': {}
+          }
+        }]
+      });
+      return request(bs.server)
+        .get('/one')
+        .set('Cookie', ['myCookie=1234'])
+        .expect(res => {
+          const csp = getHeaders(res, 'content-security-policy');
+          csp['img-src'].should.include('www.google-analytics.com');
+          csp['script-src'].should.include('www.google-analytics.com');
+          csp['connect-src'].should.include('https://region1.google-analytics.com');
+          csp['connect-src'].should.include('https://region1.analytics.google.com');
+        });
+    });
+
     it('CSP keeps default directives and excludes google directives if gaTagId not set', () => {
       const bs = bootstrap({
         csp: {},


### PR DESCRIPTION
## What? 
Adding CSP directives for Google Analytics when ga4TagId is present, not only when gaTagId is present.

## Why? 
Google Analytics tracking was broken by the v22.10.1 change to fix `gaTagId` always being truthy as it wasn't also checking for the presence of `ga4TagId` when deciding whether to add the GA directives to the CSP so any services using GA4 tags and not setting the CSP directives themselves were no longer permitting traffic sent to GA for tracking purposes.

## How? 
Included `ga4TagId` in the ln103 if statement defining whether to use the gaDirectives in the CSP.

## Testing?
Added a unit test to cover the GA4 tag and used a beta version of this change in one of our services that was broken in GA and observed traffic being logged in GA.

## Screenshots (optional)
<img width="637" height="564" alt="image" src="https://github.com/user-attachments/assets/63e47555-2ff2-48a4-b029-273b125bf308" />

## Anything Else? (optional)
## Check list

Dependabot PRs: JIRA branch/commit checklist items below do not apply to bot-generated dependency update pull requests.

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure workflow jobs are passing especially tests
- [x] I will squash the commits before merging
