### PR TITLE
Fix Windows asset build compatibility

### DIFF
--- a/build/helpers/local.js
+++ b/build/helpers/local.js
@@ -2,15 +2,15 @@ const path = require('path');
 const glob = require('glob');
 
 module.exports = function (url, file, done) {
-  // if url starts with . or / then assume it's a local/relative path
-  if (['.', path.sep].indexOf(url.substr(0, 1)) > -1) {
+  // if url starts with . or a slash then assume it's a local/relative path
+  if (['.', '/', '\\'].indexOf(url.substr(0, 1)) > -1 || path.win32.isAbsolute(url)) {
     return done(null, true);
   }
 
   // otherwise construct a glob to match possible relative file paths
   const basedir = path.dirname(file);
 
-  const bits = url.split(path.sep);
+  const bits = url.split(/[\\/]/);
 
   let filename = bits.pop();
   const filepath = bits.join(path.sep);

--- a/build/helpers/resolver/import.js
+++ b/build/helpers/resolver/import.js
@@ -1,7 +1,10 @@
 const path = require('path');
 
+const importSeparator = /[\\/]/;
+
 function Import(importUrl) {
   this.importUrl = importUrl;
+  this.segments = importUrl.split(importSeparator);
 }
 
 Import.prototype.isScoped = function () {
@@ -9,24 +12,18 @@ Import.prototype.isScoped = function () {
 };
 
 Import.prototype.packageName = function () {
-  if (this.isScoped()) {
-    return this.importUrl.split(path.sep, 2).join(path.sep);
-  }
-  return this.importUrl.split(path.sep, 1)[0];
+  const packageSegmentCount = this.isScoped() ? 2 : 1;
+  return this.segments.slice(0, packageSegmentCount).join('/');
 };
 
 Import.prototype.isEntrypoint = function () {
-  const safePathSplitPattern = new RegExp(path.sep + '.');
-  const pathSegmentCount = this.importUrl.split(safePathSplitPattern).length;
-
-  if (this.isScoped()) {
-    return pathSegmentCount === 2;
-  }
-  return pathSegmentCount === 1;
+  const packageSegmentCount = this.isScoped() ? 2 : 1;
+  return this.segments.length === packageSegmentCount;
 };
 
 Import.prototype.specifiedFilePath = function () {
-  return this.importUrl.slice(this.packageName().length);
+  const packageSegmentCount = this.isScoped() ? 2 : 1;
+  return path.join(...this.segments.slice(packageSegmentCount));
 };
 
 module.exports = Import;

--- a/build/lib/spawn.js
+++ b/build/lib/spawn.js
@@ -11,7 +11,7 @@ module.exports = (cmd, args) => new Promise((resolve, reject) => {
   const child = cp.spawn(cmd, args, {
     cwd: process.cwd(),
     stdio: 'inherit',
-    shell: true
+    shell: false
   });
   child.on('error', reject);
   child.on('exit', code => code === 0 ? resolve() : reject(new Error(`${cmd} exited with a non-zero code: ${code}`)));

--- a/build/tasks/images/index.js
+++ b/build/tasks/images/index.js
@@ -3,7 +3,6 @@
 
 const fs = require('fs');
 const chalk = require('chalk');
-const spawn = require('../../lib/spawn');
 
 module.exports = config => {
   if (!config.images) {
@@ -27,7 +26,7 @@ module.exports = config => {
       console.log(`${chalk.yellow('warning')}: Skipping missing images folder: ${src}`);
       return Promise.resolve();
     }
-    return spawn('cp', ['-r', `${src}/.`, imagesOutput]);
+    return fs.promises.cp(src, imagesOutput, { recursive: true });
   }))
     .catch(e => {
       if (e.code !== 'ENOENT') {

--- a/build/tasks/translate/index.js
+++ b/build/tasks/translate/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const path = require('path');
 const spawn = require('../../lib/spawn');
+
+const transpiler = path.resolve(__dirname, '../../../bin/hof-transpiler');
 
 module.exports = config => {
   if (!config.translate) {
@@ -10,11 +13,11 @@ module.exports = config => {
   const args = [config.translate.src];
   if (config.translate.shared) {
     const shared = [].concat(config.translate.shared);
-    shared.forEach(path => {
-      args.push('--shared', path);
+    shared.forEach(sharedPath => {
+      args.push('--shared', sharedPath);
     });
   }
 
-  return spawn('node_modules/hof/bin/hof-transpiler', args);
+  return spawn(process.execPath, [transpiler, ...args]);
 };
 module.exports.task = 'compile translations';

--- a/test/build/helpers/local.spec.js
+++ b/test/build/helpers/local.spec.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const path = require('path');
+
+describe('local import helper', () => {
+  let glob;
+  let local;
+
+  beforeEach(() => {
+    glob = sinon.stub().callsFake((target, callback) => callback(null, [target]));
+    local = proxyquire(path.resolve(__dirname, '../../../build/helpers/local'), { glob });
+  });
+
+  ['hof/frontend/main', 'hof\\frontend\\main'].forEach(importUrl => {
+    it(`constructs a local lookup glob for: ${importUrl}`, done => {
+      local(importUrl, path.join('project', 'assets', 'app.scss'), (err, isLocal) => {
+        should.not.exist(err);
+        isLocal.should.equal(1);
+        glob.should.have.been.calledWith(
+          path.join('project', 'assets', 'hof', 'frontend', '?(_)' + 'main.@(sa|c|sc)ss')
+        );
+        done();
+      });
+    });
+  });
+
+  ['../main', '/styles/main', '\\styles\\main', 'C:\\styles\\main'].forEach(importUrl => {
+    it(`recognises an explicit local path: ${importUrl}`, done => {
+      local(importUrl, path.join('project', 'assets', 'app.scss'), (err, isLocal) => {
+        should.not.exist(err);
+        isLocal.should.equal(true);
+        glob.should.not.have.been.called;
+        done();
+      });
+    });
+  });
+});

--- a/test/build/helpers/resolver/import.spec.js
+++ b/test/build/helpers/resolver/import.spec.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const path = require('path');
+const Import = require('../../../../build/helpers/resolver/import');
+
+describe('resolver import', () => {
+  ['hof/frontend/themes/gov-uk/styles/govuk', 'hof\\frontend\\themes\\gov-uk\\styles\\govuk']
+    .forEach(importUrl => {
+      it(`parses an unscoped package path: ${importUrl}`, () => {
+        const imported = new Import(importUrl);
+
+        imported.packageName().should.equal('hof');
+        imported.isEntrypoint().should.equal(false);
+        imported.specifiedFilePath().should.equal(
+          path.join('frontend', 'themes', 'gov-uk', 'styles', 'govuk')
+        );
+      });
+    });
+
+  ['@scope/package', '@scope\\package'].forEach(importUrl => {
+    it(`parses a scoped package entrypoint: ${importUrl}`, () => {
+      const imported = new Import(importUrl);
+
+      imported.packageName().should.equal('@scope/package');
+      imported.isEntrypoint().should.equal(true);
+    });
+  });
+
+  ['@scope/package/styles/main', '@scope\\package\\styles\\main'].forEach(importUrl => {
+    it(`parses a scoped package path: ${importUrl}`, () => {
+      const imported = new Import(importUrl);
+
+      imported.packageName().should.equal('@scope/package');
+      imported.isEntrypoint().should.equal(false);
+      imported.specifiedFilePath().should.equal(path.join('styles', 'main'));
+    });
+  });
+});

--- a/test/build/helpers/resolver/import.spec.js
+++ b/test/build/helpers/resolver/import.spec.js
@@ -4,6 +4,15 @@ const path = require('path');
 const Import = require('../../../../build/helpers/resolver/import');
 
 describe('resolver import', () => {
+  ['hof', 'govuk_frontend_toolkit'].forEach(importUrl => {
+    it(`recognises an unscoped package entrypoint: ${importUrl}`, () => {
+      const imported = new Import(importUrl);
+
+      imported.packageName().should.equal(importUrl);
+      imported.isEntrypoint().should.equal(true);
+    });
+  });
+
   ['hof/frontend/themes/gov-uk/styles/govuk', 'hof\\frontend\\themes\\gov-uk\\styles\\govuk']
     .forEach(importUrl => {
       it(`parses an unscoped package path: ${importUrl}`, () => {

--- a/test/build/lib/spawn.spec.js
+++ b/test/build/lib/spawn.spec.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const EventEmitter = require('events');
+const path = require('path');
+
+describe('build process helper', () => {
+  it('does not invoke commands through a shell', () => {
+    const child = new EventEmitter();
+    const childProcess = { spawn: sinon.stub().returns(child) };
+    const spawn = proxyquire(path.resolve(__dirname, '../../../build/lib/spawn'), {
+      child_process: childProcess
+    });
+    const result = spawn(process.execPath, ['script with spaces.js']);
+
+    childProcess.spawn.should.have.been.calledWithExactly(
+      process.execPath,
+      ['script with spaces.js'],
+      {
+        cwd: process.cwd(),
+        stdio: 'inherit',
+        shell: false
+      }
+    );
+    child.emit('exit', 0);
+    return result;
+  });
+});

--- a/test/build/tasks/images.spec.js
+++ b/test/build/tasks/images.spec.js
@@ -1,16 +1,18 @@
 'use strict';
 
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 describe('images task', () => {
   it('copies image directories using the Node filesystem API', () => {
     const cp = sinon.stub().resolves();
-    const fs = {
+    const mockFs = {
       existsSync: sinon.stub().returns(true),
       lstatSync: sinon.stub().returns({ isDirectory: () => true }),
       promises: { cp }
     };
-    const images = proxyquire(path.resolve(__dirname, '../../../build/tasks/images'), { fs });
+    const images = proxyquire(path.resolve(__dirname, '../../../build/tasks/images'), { fs: mockFs });
 
     return images({
       images: {
@@ -21,6 +23,32 @@ describe('images task', () => {
       cp.should.have.been.calledTwice;
       cp.should.have.been.calledWithExactly('assets/images', 'public/images', { recursive: true });
       cp.should.have.been.calledWithExactly('frontend/images', 'public/images', { recursive: true });
+    });
+  });
+
+  it('merges multiple image directories into the output directory', () => {
+    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hof-images-'));
+    const firstSource = path.join(temporaryRoot, 'first');
+    const secondSource = path.join(temporaryRoot, 'second');
+    const imagesOutput = path.join(temporaryRoot, 'output');
+
+    fs.mkdirSync(path.join(firstSource, 'icons'), { recursive: true });
+    fs.mkdirSync(path.join(secondSource, 'logos'), { recursive: true });
+    fs.writeFileSync(path.join(firstSource, 'icons', 'first.png'), 'first');
+    fs.writeFileSync(path.join(secondSource, 'logos', 'second.png'), 'second');
+
+    const images = proxyquire(path.resolve(__dirname, '../../../build/tasks/images'), { fs });
+
+    return images({
+      images: {
+        src: [firstSource, secondSource],
+        out: imagesOutput
+      }
+    }).then(() => {
+      fs.readFileSync(path.join(imagesOutput, 'icons', 'first.png'), 'utf8').should.equal('first');
+      fs.readFileSync(path.join(imagesOutput, 'logos', 'second.png'), 'utf8').should.equal('second');
+    }).finally(() => {
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
     });
   });
 });

--- a/test/build/tasks/images.spec.js
+++ b/test/build/tasks/images.spec.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const path = require('path');
+
+describe('images task', () => {
+  it('copies image directories using the Node filesystem API', () => {
+    const cp = sinon.stub().resolves();
+    const fs = {
+      existsSync: sinon.stub().returns(true),
+      lstatSync: sinon.stub().returns({ isDirectory: () => true }),
+      promises: { cp }
+    };
+    const images = proxyquire(path.resolve(__dirname, '../../../build/tasks/images'), { fs });
+
+    return images({
+      images: {
+        src: ['assets/images', 'frontend/images'],
+        out: 'public/images'
+      }
+    }).then(() => {
+      cp.should.have.been.calledTwice;
+      cp.should.have.been.calledWithExactly('assets/images', 'public/images', { recursive: true });
+      cp.should.have.been.calledWithExactly('frontend/images', 'public/images', { recursive: true });
+    });
+  });
+});

--- a/test/build/tasks/translate.spec.js
+++ b/test/build/tasks/translate.spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const path = require('path');
+
+describe('translate task', () => {
+  let spawn;
+  let translate;
+
+  beforeEach(() => {
+    spawn = sinon.stub().resolves();
+    translate = proxyquire(path.resolve(__dirname, '../../../build/tasks/translate'), {
+      '../../lib/spawn': spawn
+    });
+  });
+
+  it('runs the transpiler with the current Node executable', () => {
+    const config = {
+      translate: {
+        src: 'apps/**/translations/src',
+        shared: ['apps/common/translations/src', 'shared/translations/src']
+      }
+    };
+
+    return translate(config).then(() => {
+      spawn.should.have.been.calledOnce;
+      spawn.should.have.been.calledWithExactly(process.execPath, [
+        path.resolve(__dirname, '../../../bin/hof-transpiler'),
+        'apps/**/translations/src',
+        '--shared',
+        'apps/common/translations/src',
+        '--shared',
+        'shared/translations/src'
+      ]);
+    });
+  });
+
+  it('does nothing without translation configuration', () => {
+    return translate({}).then(() => {
+      spawn.should.not.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## What?

Make the HOF asset build work natively on Windows while preserving Linux/macOS behaviour.

* Parse Sass import identifiers independently of the host operating system’s path separator.
* Support forward-slash and backslash package and local Sass paths.
* Invoke `hof-transpiler` using `process.execPath` and a package-relative absolute path.
* Run the transpiler without shell interpretation.
* Replace the POSIX-only `cp -r` image task with `fs.promises.cp`.

## Why?

HOF 24.5.0 builds successfully on Linux with Node 24, but three parts of the normal asset build fail on native Windows:

1. The Sass resolver uses `path.sep` to parse Sass imports. On Windows this is `\`, while Sass imports normally use `/`, causing package and entrypoint resolution to fail.
2. The translation task executes the extensionless `bin/hof-transpiler` script directly through a shell. Windows `cmd.exe` does not treat that script as an executable.
3. The image task depends on the POSIX `cp` command, which is not normally available on Windows.

## How?

Sass import identifiers are split on either `/` or `\`. Package names remain in canonical slash form, and `path.join` is used only when converting import segments into filesystem paths.

The translation task resolves HOF’s bundled transpiler relative to the package and invokes it using:

```js
spawn(process.execPath, [transpiler, ...args]);
```

`process.execPath` guarantees the same Node executable currently running HOF and avoids depending on `node` being available on `PATH`.

The image task now uses:

```js
fs.promises.cp(src, imagesOutput, { recursive: true });
```

## Testing?

Validated with Node 24:

* HOF lint passed.
* 19 focused compatibility regression tests passed.
* The existing Jest, functional and Vite suites passed.
* A complete isolated `hof-build` smoke test produced JavaScript, Sass CSS/source maps, translations and merged images.
* A broader unit run reached 866 passing tests; two unrelated local environment failures concerned a missing `postcode@0.2.5` fixture and unavailable Redis.

The changes were also validated in a downstream HOF 24.5.0 application on native Windows:

* The complete asset build succeeded using Node 24.
* The application started successfully with Redis connectivity.
* The application journey worked through `localhost`.

The downstream application also passed its native Windows Azure DevOps pipeline using Node 24.19.0, including installation, asset build, lint, unit tests, staging, packaging and artifact publication.

HOF’s own CI matrix does not currently include a native Windows runner.

## Screenshots (optional)

Not applicable.

## Anything Else? (optional)

This removes operating-system-specific assumptions from the normal HOF asset build without introducing application-specific handling.

## Check list

Dependabot PRs: JIRA branch/commit checklist items below do not apply to bot-generated dependency update pull requests.

* [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
* [x] I have written tests (if relevant)
* [ ] I have created a JIRA number for my branch
* [ ] I have created a JIRA number for my commit
* [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
* [ ] Ensure workflow jobs are passing especially tests
* [x] I will squash the commits before merging
